### PR TITLE
#10 Properly destroy the underlying MQTTAsync handle by calling MQTTA…

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -923,8 +923,17 @@ impl AsyncClient {
 
 impl Drop for AsyncClient {
     fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                ffi::MQTTAsync_destroy(&mut self.handle as *mut *mut c_void);
+            }
+        }
         if !self.persistence_ptr.is_null() {
             unsafe {
+                let context = (*self.persistence_ptr).context;
+                if !context.is_null() {
+                    drop(Box::from_raw(context));
+                }
                 drop(Box::from_raw(self.persistence_ptr));
             }
         }


### PR DESCRIPTION
…sync_destroy in the implementation of AsyncClient::drop.