### PR TITLE
Properly destroy the underlying MQTTAsync handle by calling MQTTAsync_destroy in the implementation of AsyncClient::drop.

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -923,8 +923,17 @@ impl AsyncClient {
 
 impl Drop for AsyncClient {
     fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe {
+                ffi::MQTTAsync_destroy(&mut self.handle as *mut *mut c_void);
+            }
+        }
         if !self.persistence_ptr.is_null() {
             unsafe {
+                let context = (*self.persistence_ptr).context;
+                if !context.is_null() {
+                    drop(Box::from_raw(context));
+                }
                 drop(Box::from_raw(self.persistence_ptr));
             }
         }


### PR DESCRIPTION
Also, we will drop the boxed ClientPersistence trait object inside of the ffi::MQTTClient_persistence. This currently leaks because it is forgotten (via Box::into_raw) during AsyncClient::new(), and it is not freed on the C side.