### PR TITLE
#17 Created an inner box for the AsyncClient

### DIFF
--- a/examples/async_subscribe.rs
+++ b/examples/async_subscribe.rs
@@ -82,7 +82,7 @@ fn main() {
     // Set a closure to be called whenever the client loses the connection.
     // It will attempt to reconnect, and set up function callbacks to keep
     // retrying until the connection is re-established.
-    cli.set_connection_lost_callback(|cli: &mut mqtt::AsyncClient| {
+    cli.set_connection_lost_callback(|cli: &mqtt::AsyncClient| {
         println!("Connection lost. Attempting reconnect.");
         thread::sleep(Duration::from_millis(2500));
         cli.reconnect_with_callbacks(on_connect_success, on_connect_failure);


### PR DESCRIPTION
Moved the guts of the AsyncClient into an "inner" struct `InnerAsyncClient` and boxed it into the outer client, like this:
```
pub struct AsyncClient {
    inner: Box<InnerAsyncClient>,
}
```
The address of the inner struct will remain fixed in the heap even if the outer client is moved. This should make it safer to use the address of the inner struct as a callback context.