### PR TITLE
Futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ pub fn publish(&self, msg: Message) -> DeliveryToken { ... }
 ```
 - Cloning a `Token` just creates a new `Arc` pointer to the same `TokenInner` struct.
 - `Token` callbacks now implement `Fn` instead of `FnMut`.
+- `Token::wait()` and `Token::wait_for()` now consume the Token (i.e. they take `self` instead of `&self`).
 
 
 ## [v0.5](https://github.com/eclipse/paho.mqtt.rust/compare/v0.4..v0.5) - 2018-12-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+- `Token` has pushed its data members down a level into a `TokenInner` structure, and now `Token` just has an `Arc<TokenInner>` member.
+- `AsyncClient` asynchronous functions now return `Token` instead of `Arc<Token>`, like:
+```
+pub fn connect<T>(&self, opt_opts: T) -> Token { ... }
+pub fn reconnect(&self) -> Token { ... }
+pub fn disconnect<T>(&self, opt_opts: T) -> Token { ... }
+pub fn publish(&self, msg: Message) -> DeliveryToken { ... }
+```
+- Cloning a `Token` just creates a new `Arc` pointer to the same `TokenInner` struct.
+- `Token` callbacks now implement `Fn` instead of `FnMut`.
+
+
+## [v0.5](https://github.com/eclipse/paho.mqtt.rust/compare/v0.4..v0.5) - 2018-12-15
+
+### Added
+
+- WebSocket support (free with Paho C 1.3.0 update).
+- Example apps can take server URI's from the command line.
+
+### Changed
+
+- Updated the library to bundle and use Paho C v1.3.0
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paho-mqtt"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Frank Pagliughi <fpagliughi@mindspring.com>"]
 homepage = "https://github.com/eclipse/paho.mqtt.rust"
 repository = "https://github.com/eclipse/paho.mqtt.rust"
@@ -15,8 +15,9 @@ This is a wrapper around the Paho C library.
 [dependencies]
 paho-mqtt-sys = { version = "0.2", path = "paho-mqtt-sys", default-features=false }
 libc = "0.2"
-log = "0.3"
-env_logger = "0.3"
+futures = "0.1"
+log = "0.4"
+env_logger = "0.6"
 
 [features]
 default = ["bundled", "ssl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ This is a wrapper around the Paho C library.
 paho-mqtt-sys = { version = "0.2", path = "paho-mqtt-sys", default-features=false }
 libc = "0.2"
 futures = "0.1"
+futures-timer = "0.1"
 log = "0.4"
 env_logger = "0.6"
 

--- a/README.md
+++ b/README.md
@@ -22,37 +22,41 @@ To keep up with the latest announcements for this project, follow:
 
 **EMail:** [Eclipse Paho Mailing List](https://accounts.eclipse.org/mailing-list/paho-dev)
 
-Unreleased Features 
+### Unreleased Features (in this branch) 
 
-- Bundled Paho C Library upgraded to v1.3.0
-- WebSocket support
+- **Futures support:**
+    - Compatible with the [Rust Futures](https://docs.rs/futures/0.1.25/futures/) library v0.1
+    - The `Token` object, which is returned by asynchronous calls, now implements the `Futures` trait, which is _mostly_ compatible with the previous implementation.
+    - Incoming messages can be obtained through a `Stream` from the client, implemented with a futures channel.
+    - New examples of a publisher and subscriber implemented with futures.
 
 
 ### Features
 
 The initial version of the library is a wrapper for the Paho C library, similar to the implementation for the current Paho C++ library. It targets MQTT v3.1 and 3.1.1, and includes all of the features available in the C library for those versions, including:
 
-* Standard TCP support
-* SSL / TLS
-* WebSockets
-* QoS 0, 1, and 2
-* Last Will and Testament (LWT)
-* Message Persistence 
-    * File or memory persistence
-    * User-defined persistence
-* Automatic Reconnect
-* Offline Buffering
-* High Availability
-* Asynchronous (Non-blocking) API
-* Synchronous (Blocking)  API
+- Standard TCP support
+- SSL / TLS
+- WebSockets
+- QoS 0, 1, and 2
+- Last Will and Testament (LWT)
+- Message Persistence 
+    - File or memory persistence
+    - User-defined persistence
+- Automatic Reconnect
+- Offline Buffering
+- High Availability
+- Rust Futures and Streams for asynchronous operations.
+- Traditional asynchronous API
+- Synchronous/blocking  API
 
-### Future Release
+Supports Paho C v1.3.0
 
-This crate was initially started with the intention of being a quick re-write of the Paho C++ crate, which was used as a template for a rough API and implementation. The hope was more to introduce Rust to the the MQTT community than the other way around. Thus, this initial version lacks tight integration into some of the de facto libraries used in Rust for this type of library, such as *futures* and *tokio*.
+### Upcoming Release(s)
 
-This will, hopefully, be remidied very soon.
+As soon as the current version is stabilized and released, work will immediately begin to bring in support for MQTT v5.
 
-As soon as the current version is stabilized and released, work will immediately begin on a version to wrap the recently-released Paho C v1.3 to bring in support for MQTT v5 and WebSockets. At that time, we will also introduce integration with futures and optional *tokio* support.
+Prior to that, the plan is to allow the Futures support to settle, improve error handling and reporting, and clean up the internal implementation.
 
 ## Building the Crate
 

--- a/examples/async_persist_publish.rs
+++ b/examples/async_persist_publish.rs
@@ -28,6 +28,7 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
+extern crate futures;
 #[macro_use]
 extern crate log;
 extern crate env_logger;
@@ -35,6 +36,7 @@ extern crate paho_mqtt as mqtt;
 
 use std::process;
 use std::collections::HashMap;
+use futures::Future;
 
 // Use a non-zero QOS to exercise the persistence store
 const QOS: i32 = 1;
@@ -134,7 +136,7 @@ impl mqtt::ClientPersistence for MemPersistence
 
 fn main() {
     // Initialize the logger from the environment
-    env_logger::init().unwrap();
+    env_logger::init();
 
     // Create a client & define connect options
     println!("Creating the MQTT client.");

--- a/examples/async_publish.rs
+++ b/examples/async_publish.rs
@@ -24,15 +24,17 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
+extern crate futures;
 extern crate log;
 extern crate env_logger;
 extern crate paho_mqtt as mqtt;
 
 use std::{env, process};
+use futures::Future;
 
 fn main() {
     // Initialize the logger from the environment
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let host = env::args().skip(1).next().unwrap_or(
         "tcp://localhost:1883".to_string()

--- a/examples/async_subscribe.rs
+++ b/examples/async_subscribe.rs
@@ -71,7 +71,7 @@ fn on_connect_failure(cli: &mqtt::AsyncClient, _msgid: u16, rc: i32) {
 
 fn main() {
     // Initialize the logger from the environment
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let host = env::args().skip(1).next().unwrap_or(
         "tcp://localhost:1883".to_string()

--- a/examples/futures_consume.rs
+++ b/examples/futures_consume.rs
@@ -1,0 +1,119 @@
+// paho-mqtt/examples/futures_consume.rs
+// This is a Paho MQTT Rust client, sample application.
+//
+//! This application is an MQTT subscriber using the asynchronous futures
+//! stream interface of the Paho Rust client library, employing callbacks
+//! to receive messages and status updates. It also monitors for disconnects
+//! and performs manual re-connections.
+//!
+//! The sample demonstrates:
+//!   - Futures stream for receiving messages
+//!   - Connecting to an MQTT server/broker.
+//!   - Subscribing to multiple topics
+//!   - Using automatic reconnect to let the underlying library reconnect to
+//!     the server on lost connections
+//!   - Using a persistent (non-clean) session to get all messages even with
+//!     transient lost connections.
+//!   - Last will and testament
+//!
+
+/*******************************************************************************
+ * Copyright (c) 2018 Frank Pagliughi <fpagliughi@mindspring.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Frank Pagliughi - initial implementation and documentation
+ *******************************************************************************/
+
+extern crate log;
+extern crate env_logger;
+extern crate futures;
+extern crate paho_mqtt as mqtt;
+
+use std::{env, process};
+use std::time::Duration;
+
+use futures::{Future, Stream};
+use futures::future::ok;
+
+// The topics to which we subscribe.
+const TOPICS: &[&str] = &[ "test", "hello" ];
+const QOS: &[i32] = &[1, 1];
+
+/////////////////////////////////////////////////////////////////////////////
+
+fn main() {
+    // Initialize the logger from the environment
+    env_logger::init();
+
+    // Get a host URL from the command line, if any
+    let host = env::args().skip(1).next().unwrap_or(
+        "tcp://localhost:1883".to_string()
+    );
+
+    // Create the client. Use an ID for a persistent session.
+    // A real system should try harder to use a unique ID.
+    let create_opts = mqtt::CreateOptionsBuilder::new()
+        .server_uri(host)
+        .client_id("rust_futures_consumer")
+        .finalize();
+
+    // Create the client connection
+    let mut cli = mqtt::AsyncClient::new(create_opts).unwrap_or_else(|e| {
+        println!("Error creating the client: {:?}", e);
+        process::exit(1);
+    });
+
+    // Define the set of options for the connection (persistent session,
+    // auto reconnect, Last Will and Testament (lwt), etc)
+    let lwt = mqtt::Message::new("failure", "Futures consumer lost connection", 1);
+
+    let conn_opts = mqtt::ConnectOptionsBuilder::new()
+        .mqtt_version(mqtt::MQTT_VERSION_3_1_1)
+        .keep_alive_interval(Duration::from_secs(20))
+        .automatic_reconnect(Duration::from_millis(500), Duration::from_secs(30))
+        .clean_session(false)
+        .will_message(lwt)
+        .finalize();
+
+    // Open the receiver stream before we even try to connect. This
+    // insures that we don't miss any messages, even when a restart of the
+    // app gets us a flood of stored messages from the persistent session.
+    let rx = cli.get_stream(10);
+
+    // Make the connection to the broker
+    println!("Connecting to the MQTT server...");
+    cli.connect(conn_opts).wait().unwrap_or_else(|err| {
+        println!("Error: {}", err);
+        process::exit(2);
+    });
+
+    // Subscribe to multiple topics
+    println!("Subscribing to topics: {:?}", TOPICS);
+    cli.subscribe_many(TOPICS, QOS);
+
+    // Just wait for incoming messages by running the receiver stream
+    // in this thread.
+    println!("Waiting for messages...");
+    rx.for_each(|opt_msg| {
+        if let Some(msg) = opt_msg {
+            println!("{}", msg);
+        }
+        else {
+            println!("Stream disruption");
+        }
+        ok(())
+    }).wait().unwrap();
+
+    // Hitting ^C will exit the app and cause the broker to publish
+    // the LWT message since we're not disconnecting cleanly.
+}
+

--- a/examples/futures_publish.rs
+++ b/examples/futures_publish.rs
@@ -48,13 +48,13 @@ fn main() {
     });
 
     // Connect, send a message, and disconnect
-    if let Err(err) = cli.connect(None)
-            .and_then(|_| {
-                println!("Publishing a message on the 'test' topic");
-                let msg = mqtt::Message::new("test", "Hello world!", 0);
-                cli.publish(msg)
-            })
-            .and_then(|_| cli.disconnect(None)).wait() {
-        println!("Error: {}", err);
-    }
+    cli.connect(None)
+        .and_then(|_| {
+            println!("Publishing a message on the 'test' topic");
+            let msg = mqtt::Message::new("test", "Hello futures world!", 0);
+            cli.publish(msg)
+        })
+        .and_then(|_| cli.disconnect(None)).wait().unwrap_or_else(|err| {
+            println!("Error: {}", err);
+        });
 }

--- a/examples/futures_publish.rs
+++ b/examples/futures_publish.rs
@@ -1,0 +1,60 @@
+// paho-mqtt/examples/futures_publish.rs
+//
+//! This is a simple MQTT asynchronous message publisher with Rust Futures
+//! using the Paho Rust library.
+//!
+//! This sample demonstrates:
+//!   - Connecting to an MQTT broker
+//!   - Publishing a message asynchronously using Futures
+//
+
+/*******************************************************************************
+ * Copyright (c) 2018 Frank Pagliughi <fpagliughi@mindspring.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Frank Pagliughi - initial implementation and documentation
+ *******************************************************************************/
+
+extern crate futures;
+extern crate log;
+extern crate env_logger;
+extern crate paho_mqtt as mqtt;
+
+use std::{env, process};
+use futures::Future;
+
+fn main() {
+    // Initialize the logger from the environment
+    env_logger::init();
+
+    // Get the server URL, if one is given on the command line
+    let host = env::args().skip(1).next().unwrap_or(
+        "tcp://localhost:1883".to_string()
+    );
+
+    // Create a client & define connect options
+    let cli = mqtt::AsyncClient::new(host).unwrap_or_else(|err| {
+        println!("Error creating the client: {}", err);
+        process::exit(1);
+    });
+
+    // Connect, send a message, and disconnect
+    if let Err(err) = cli.connect(None)
+            .and_then(|_| {
+                println!("Publishing a message on the 'test' topic");
+                let msg = mqtt::Message::new("test", "Hello world!", 0);
+                cli.publish(msg)
+            })
+            .and_then(|_| cli.disconnect(None)).wait() {
+        println!("Error: {}", err);
+    }
+}

--- a/examples/ssl_publish.rs
+++ b/examples/ssl_publish.rs
@@ -36,15 +36,17 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
+extern crate futures;
 extern crate log;
 extern crate env_logger;
 extern crate paho_mqtt as mqtt;
 
 use std::{time, env, process};
+use futures::Future;
 
 fn main() {
     // Initialize the logger from the environment
-    env_logger::init().unwrap();
+    env_logger::init();
 
     // We use the trust store from the Paho C tls-testing/keys directory,
     // but we assume there's a copy in the current directory.

--- a/examples/sync_consume.rs
+++ b/examples/sync_consume.rs
@@ -99,9 +99,11 @@ fn main() {
         process::exit(1);
     };
 
-    // Initialize the consumer & subscribe to topics
-    println!("Subscribing to topics...");
+    // Initialize the consumer before subscribing to topics
     let rx = cli.start_consuming();
+
+    // Register subscriptions on the server
+    println!("Subscribing to topics...");
 
     let subscriptions = [ "test", "hello" ];
     let qos = [1, 1];

--- a/examples/sync_consume.rs
+++ b/examples/sync_consume.rs
@@ -62,7 +62,7 @@ fn try_reconnect(cli: &mqtt::Client) -> bool
 
 fn main() {
     // Initialize the logger from the environment
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let host = env::args().skip(1).next().unwrap_or(
         "tcp://localhost:1883".to_string()

--- a/examples/sync_publish.rs
+++ b/examples/sync_publish.rs
@@ -34,7 +34,7 @@ use std::{env, process};
 
 fn main() {
     // Initialize the logger from the environment
-    env_logger::init().unwrap();
+    env_logger::init();
 
     // Create a client & define connect options
     let host = env::args().skip(1).next().unwrap_or(

--- a/examples/topic_publish.rs
+++ b/examples/topic_publish.rs
@@ -26,17 +26,19 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
+extern crate futures;
 extern crate log;
 extern crate env_logger;
 extern crate paho_mqtt as mqtt;
 
 use std::{env, process};
+use futures::Future;
 
 const QOS: i32 = 1;
 
 fn main() {
 	// Initialize the logger from the environment
-	env_logger::init().unwrap();
+	env_logger::init();
 
     let host = env::args().skip(1).next().unwrap_or(
         "tcp://localhost:1883".to_string()

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -62,8 +62,9 @@ use connect_options::ConnectOptions;
 use disconnect_options::{DisconnectOptions,DisconnectOptionsBuilder};
 use message::Message;
 use token::{Token, DeliveryToken};
-use client_persistence::{/*ClientPersistence,*/ ClientPersistenceBridge};
-use errors::{MqttResult, /*MqttError,*/ ErrorKind};
+use client_persistence::{ClientPersistenceBridge};
+use errors;
+use errors::{MqttResult, ErrorKind};
 use string_collection::{StringCollection};
 
 /////////////////////////////////////////////////////////////////////////////
@@ -247,7 +248,7 @@ impl AsyncClient {
 
         if rc != 0 {
             warn!("Create result: {}", rc);
-            fail!((ErrorKind::General, rc, Token::error_msg(rc)));
+            fail!((ErrorKind::General, rc, errors::error_message(rc)));
         }
         debug!("AsyncClient handle: {:?}", cli.handle);
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1,3 +1,4 @@
+
 // paho-mqtt/src/async_client.rs
 // This file is part of the Eclipse Paho MQTT Rust Client library.
 
@@ -19,9 +20,9 @@
 
 //! The Asynchronous client module for the Paho MQTT Rust client library.
 //!
-//! Currently this presents an asynchronous API that is similar to the
-//! other Paho MQTT clients, but is not based on any other Rust async
-//! library like mio or tokio.
+//! This presents an asynchronous API that is similar to the other Paho MQTT
+//! clients, but but uses Token objects that implement the Futures trait, so
+//! can be used in much more flexible ways than the other language clients.
 //!
 //! Asynchronous operations return a `Token` that is a type of future. It
 //! can be used to determine if an operation has completed, block and wait
@@ -46,7 +47,7 @@
 use std::str;
 use std::{ptr, slice, mem};
 use std::time::Duration;
-use std::sync::{Arc, Mutex, Condvar};
+use std::sync::{Arc, Mutex};
 use std::ffi::{CString, CStr};
 use std::os::raw::{c_void, c_char, c_int};
 use std::sync::mpsc::{Sender, Receiver};
@@ -58,273 +59,10 @@ use create_options::{CreateOptions,PersistenceType};
 use connect_options::ConnectOptions;
 use disconnect_options::{DisconnectOptions,DisconnectOptionsBuilder};
 use message::Message;
+use token::{Token, DeliveryToken};
 use client_persistence::{/*ClientPersistence,*/ ClientPersistenceBridge};
 use errors::{MqttResult, /*MqttError,*/ ErrorKind};
 use string_collection::{StringCollection};
-
-/////////////////////////////////////////////////////////////////////////////
-// Token
-
-/// Callback for the token on successful completion
-pub type SuccessCallback = FnMut(&AsyncClient, u16) + 'static;
-
-/// Callback for the token on failed completion
-pub type FailureCallback = FnMut(&AsyncClient, u16, i32) + 'static;
-
-/// The result data for the token.
-/// This is the guarded elements in the token which are updated by the
-/// C library callback when the operation completes.
-struct TokenData {
-    /// Whether the async action has completed
-    complete: bool,
-    /// The MQTT Message ID
-    msg_id: i16,
-    /// The return/error code for the action (zero is success)
-    ret_code: i32,
-    /// The error message (if any)
-    err_msg: String,
-}
-
-
-/// A `Token` is a mechanism for tracking the progress of an asynchronous
-/// operation.
-pub struct Token {
-    // Mutex guards: (done, ret, msgid)
-    lock: Mutex<TokenData>,
-    // Signal for when the state changes
-    cv: Condvar,
-    // Pointer to the client that created the token.
-    // This is only guaranteed valid until the end of the callback
-    cli: *const AsyncClient,
-    // User callback for successful completion of the async action
-    on_success: Option<Box<SuccessCallback>>,
-    // User callback for failed completion of the async action
-    on_failure: Option<Box<FailureCallback>>,
-    // The message (valid only for "delivery" tokens)
-    msg: Option<Message>,
-}
-
-impl Token {
-    /// Creates a new, unsignaled Token.
-    pub fn new() -> Token {
-        Token {
-            lock: Mutex::new(TokenData {
-                complete: false,
-                msg_id: 0,
-                ret_code: 0,
-                err_msg: "".to_string(),
-            }),
-            cv: Condvar::new(),
-            cli: ptr::null(),
-            on_success: None,
-            on_failure: None,
-            msg: None
-        }
-    }
-
-    /// Creates a new, un-signaled delivery Token.
-    /// This is a token which tracks delivery of a message.
-    pub fn from_message(msg: Message) -> Token {
-        Token {
-            lock: Mutex::new(TokenData {
-                complete: false,
-                msg_id: msg.cmsg.msgid as i16,
-                ret_code: 0,
-                err_msg: "".to_string(),
-            }),
-            cv: Condvar::new(),
-            cli: ptr::null(),
-            on_success: None,
-            on_failure: None,
-            msg: Some(msg),
-        }
-    }
-
-    /// Creates a new, un-signaled Token with callbacks.
-    pub fn from_client<FS,FF>(cli: *const AsyncClient,
-                              success_cb: FS,
-                              failure_cb: FF) -> Token
-        where FS: FnMut(&AsyncClient, u16) + 'static,
-              FF: FnMut(&AsyncClient, u16,i32) + 'static
-    {
-        Token {
-            lock: Mutex::new(TokenData {
-                complete: false,
-                msg_id: 0,
-                ret_code: 0,
-                err_msg: "".to_string(),
-            }),
-            cv: Condvar::new(),
-            cli: cli,
-            on_success: Some(Box::new(success_cb)),
-            on_failure: Some(Box::new(failure_cb)),
-            msg: None
-        }
-    }
-
-    /// Creates a new Token signaled with an error.
-    pub fn from_error(rc: i32) -> Token {
-        Token {
-            lock: Mutex::new(TokenData {
-                complete: true,
-                msg_id: 0,
-                ret_code: rc,
-                err_msg: String::from(Token::error_msg(rc)),
-            }),
-            cv: Condvar::new(),
-            cli: ptr::null(),
-            on_success: None,
-            on_failure: None,
-            msg: None
-        }
-    }
-
-    // Callback from the C library for when an async operation succeeds.
-    unsafe extern "C" fn on_success(context: *mut c_void, rsp: *mut ffi::MQTTAsync_successData) {
-        debug!("Token success! {:?}, {:?}", context, rsp);
-        if context.is_null() {
-            return
-        }
-        let msgid = if !rsp.is_null() { (*rsp).token as u16 } else { 0 };
-        let tokptr = context as *mut Token;
-        let tok = &mut *tokptr;
-        tok.on_complete(&*tok.cli, msgid, 0, "".to_string());
-        let _ = Arc::from_raw(tokptr);
-    }
-
-    // Callback from the C library when an async operation fails.
-    unsafe extern "C" fn on_failure(context: *mut c_void, rsp: *mut ffi::MQTTAsync_failureData) {
-        warn!("Token failure! {:?}, {:?}", context, rsp);
-        if context.is_null() {
-            return
-        }
-        let mut msgid = 0;
-        let mut rc = -1;
-        let mut msg = "Error".to_string();
-
-        if !rsp.is_null() {
-            msgid = (*rsp).token as u16;
-            rc = if (*rsp).code == 0 { -1i32 } else { (*rsp).code as i32 };
-
-            if !(*rsp).message.is_null() {
-                if let Ok(cmsg) = CStr::from_ptr((*rsp).message).to_str() {
-                    debug!("Token failure message: {:?}", cmsg);
-                    msg = cmsg.to_string();
-                }
-            }
-        }
-
-        if msg.is_empty() {
-            let emsg = Token::error_msg(rc);
-            msg = emsg.to_string();
-        }
-
-        let tokptr = context as *mut Token;
-        let tok = &mut *tokptr;
-        // TODO: Check client null?
-        tok.on_complete(&*tok.cli, msgid, rc, msg);
-        let _ = Arc::from_raw(tokptr);
-    }
-
-    // Callback function to update the token when the action completes.
-    fn on_complete(&mut self, cli: &AsyncClient, msgid: u16, rc: i32, msg: String) {
-        debug!("Token completed with code: {}", rc);
-        {
-            let mut retv = self.lock.lock().unwrap();
-            (*retv).complete = true;
-            (*retv).ret_code = rc;
-            (*retv).err_msg = msg;
-        }
-        if rc == 0 {
-            if let Some(ref mut cb) = self.on_success {
-                trace!("Invoking Token::on_success callback");
-                cb(cli, msgid);
-            }
-        }
-        else {
-            if let Some(ref mut cb) = self.on_failure {
-                trace!("Invoking Token::on_failure callback");
-                cb(cli, msgid, rc);
-            }
-        }
-        self.cv.notify_all();
-    }
-
-    // Gets the string associated with the error code from the C lib.
-    fn error_msg(rc: i32) -> &'static str {
-        match rc {
-            ffi::MQTTASYNC_FAILURE => "General failure",
-            ffi::MQTTASYNC_PERSISTENCE_ERROR /* -2 */ => "Persistence error",
-            ffi::MQTTASYNC_DISCONNECTED => "Client disconnected",
-            ffi::MQTTASYNC_MAX_MESSAGES_INFLIGHT => "Maximum inflight messages",
-            ffi::MQTTASYNC_BAD_UTF8_STRING => "Bad UTF8 string",
-            ffi::MQTTASYNC_NULL_PARAMETER => "NULL Parameter",
-            ffi::MQTTASYNC_TOPICNAME_TRUNCATED => "Topic name truncated",
-            ffi::MQTTASYNC_BAD_STRUCTURE => "Bad structure",
-            ffi::MQTTASYNC_BAD_QOS => "Bad QoS",
-            ffi::MQTTASYNC_NO_MORE_MSGIDS => "No more message ID's",
-            ffi::MQTTASYNC_OPERATION_INCOMPLETE => "Operation incomplete",
-            ffi::MQTTASYNC_MAX_BUFFERED_MESSAGES => "Max buffered messages",
-            ffi::MQTTASYNC_SSL_NOT_SUPPORTED => "SSL not supported by Paho C library",
-             _ => "",
-        }
-    }
-
-
-    /// Sets the message ID for the token
-    fn set_msgid(&self, msg_id: i16) {
-        let mut retv = self.lock.lock().unwrap();
-        (*retv).msg_id = msg_id;
-    }
-
-
-    /// Blocks the caller until the asynchronous operation has completed.
-    pub fn wait(&self) -> MqttResult<()> {
-        let mut retv = self.lock.lock().unwrap();
-
-        // As long as the 'done' value inside the `Mutex` is false, we wait.
-        while !(*retv).complete {
-            retv = self.cv.wait(retv).unwrap();
-        }
-
-        let rc = (*retv).ret_code;
-        debug!("Token completed: {}", rc);
-        if rc != 0 {
-            let msg = Token::error_msg(rc);
-            fail!((ErrorKind::General, rc, "Error", msg));
-        }
-        Ok(())
-    }
-
-    /// Blocks the caller a limited amount of time waiting for the
-    /// asynchronous operation to complete.
-    pub fn wait_for(&self, dur: Duration) -> MqttResult<()> {
-        let mut retv = self.lock.lock().unwrap();
-
-        while !(*retv).complete {
-            let result = self.cv.wait_timeout(retv, dur).unwrap();
-
-            if result.1.timed_out() {
-                fail!(::std::io::Error::new(::std::io::ErrorKind::TimedOut, "Timed out"));
-            }
-            retv = result.0;
-        }
-
-        let rc = (*retv).ret_code;
-        debug!("Timed token completed: {}", rc);
-        if rc != 0 {
-            let msg = Token::error_msg(rc);
-            fail!((ErrorKind::General, rc, "Error", msg));
-        }
-
-        Ok(())
-    }
-}
-
-/// `Token` specificly for a message delivery operation.
-/// Originally this was a distinct object, but the implementation was
-/// absorbed into a standard `Token`.
-pub type DeliveryToken = Token;
 
 /////////////////////////////////////////////////////////////////////////////
 // AsynClient
@@ -1104,7 +842,6 @@ impl AsyncClientBuilder {
 }
 
 /////////////////////////////////////////////////////////////////////////////
-
 
 #[cfg(test)]
 mod tests {

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -30,7 +30,10 @@
 //! wait for the connection to complete.
 //!
 //! ```
+//! extern crate futures;
 //! extern crate paho_mqtt as mqtt;
+//!
+//! use futures::future::Future;
 //!
 //! let cli = mqtt::AsyncClient::new("tcp://localhost:1883").unwrap();
 //!

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -45,7 +45,14 @@ pub fn error_message(rc: i32) -> &'static str {
     }
 }
 
-/// The possible errors
+/////////////////////////////////////////////////////////////////////////////
+
+/// An MQTT Error
+pub struct MqttError {
+    repr: ErrorRepr,
+}
+
+/// The possible error types
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum ErrorKind {
     /// General Failure
@@ -60,11 +67,7 @@ pub enum ErrorKind {
     IoError,
 }
 
-/// An MQTT Error
-pub struct MqttError {
-    repr: ErrorRepr,
-}
-
+/// The internal representations of the error
 #[derive(Debug)]
 enum ErrorRepr {
     WithDescription(ErrorKind, i32, &'static str),
@@ -73,6 +76,7 @@ enum ErrorRepr {
 }
 
 impl From<io::Error> for MqttError {
+    /// Create an MqttError from an I/O error
     fn from(err: io::Error) -> MqttError {
         MqttError {
             repr: ErrorRepr::IoError(err),
@@ -81,6 +85,7 @@ impl From<io::Error> for MqttError {
 }
 
 impl From<Utf8Error> for MqttError {
+    /// Create an MqttError from a UTF error
     fn from(_: Utf8Error) -> MqttError {
         MqttError {
             repr: ErrorRepr::WithDescription(ErrorKind::TypeError, -1, "Invalid UTF-8"),
@@ -98,7 +103,7 @@ impl From<i32> for MqttError {
 }
 
 impl From<(i32,String)> for MqttError {
-    /// Creates an MqttError from a Paho C return code.
+    /// Creates an MqttError from a Paho C return code and additional detail string.
     fn from((rc, detail): (i32,String)) -> MqttError {
         MqttError {
             repr: ErrorRepr::WithDescriptionAndDetail(ErrorKind::General, rc, error_message(rc), detail),
@@ -131,8 +136,7 @@ impl From<(ErrorKind, &'static str, String)> for MqttError {
 }
 
 impl<S> From<(ErrorKind, i32, &'static str, S)> for MqttError
-where
-    S: Into<String>,
+    where S: Into<String>,
 {
     fn from((kind, err, desc, detail): (ErrorKind, i32, &'static str, S)) -> MqttError {
         MqttError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -102,11 +102,13 @@ impl From<i32> for MqttError {
     }
 }
 
-impl From<(i32,String)> for MqttError {
+impl<S> From<(i32,S)> for MqttError
+    where S: Into<String>
+{
     /// Creates an MqttError from a Paho C return code and additional detail string.
-    fn from((rc, detail): (i32,String)) -> MqttError {
+    fn from((rc, detail): (i32,S)) -> MqttError {
         MqttError {
-            repr: ErrorRepr::WithDescriptionAndDetail(ErrorKind::General, rc, error_message(rc), detail),
+            repr: ErrorRepr::WithDescriptionAndDetail(ErrorKind::General, rc, error_message(rc), detail.into()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@
 // Temporary
 #![allow(dead_code)]
 
+extern crate futures;
+
 #[macro_use]
 extern crate log;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 #![allow(dead_code)]
 
 extern crate futures;
+extern crate futures_timer;
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ pub use will_options::*;        //{WillOptions, WillOptionsBuilder};
 pub use ssl_options::*;         //{SslOptions, SslOptionsBuilder};
 pub use disconnect_options::*;  //{DisconnectOptions, DisconnectOptionsBuilder};
 pub use message::*;             //{Message, MessageBuilder};
+pub use token::*;               //{Token}
 pub use topic::*;               //{Topic}
 pub use client_persistence::*;
 pub use errors::*;              //{MqttResult, MqttError, ErrorKind};
@@ -75,6 +76,9 @@ pub mod disconnect_options;
 
 /// The message object
 pub mod message;
+
+/// Tokens to monitor asynchronous operations
+pub mod token;
 
 /// Options for creating topic objects that are associated with a
 /// particular server.

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,324 @@
+// paho-mqtt/src/token.rs
+// This file is part of the Eclipse Paho MQTT Rust Client library.
+
+/*******************************************************************************
+ * Copyright (c) 2018 Frank Pagliughi <fpagliughi@mindspring.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Frank Pagliughi - initial implementation and documentation
+ *******************************************************************************/
+
+//! The Token module for the Paho MQTT Rust client library.
+//!
+//! Asynchronous operations return a `Token` that is a type of future. It
+//! can be used to determine if an operation has completed, block and wait
+//! for the operation to complete, and obtain the final result.
+//! For example, you can start a connection, do something else, and then
+//! wait for the connection to complete.
+//!
+//! The Token object implements the Future trait, and thus can be used and
+//! combined with any other Rust futures.
+//!
+
+use std::{str, ptr};
+use std::time::Duration;
+use std::sync::{Arc, Mutex, Condvar};
+use std::ffi::{CStr};
+use std::os::raw::{c_void};
+
+use ffi;
+
+use async_client::AsyncClient;
+use message::Message;
+use errors::{MqttResult, /*MqttError,*/ ErrorKind};
+
+/////////////////////////////////////////////////////////////////////////////
+// Token
+
+/// Callback for the token on successful completion
+pub type SuccessCallback = FnMut(&AsyncClient, u16) + 'static;
+
+/// Callback for the token on failed completion
+pub type FailureCallback = FnMut(&AsyncClient, u16, i32) + 'static;
+
+/// The result data for the token.
+/// This is the guarded elements in the token which are updated by the
+/// C library callback when the operation completes.
+struct TokenData {
+    /// Whether the async action has completed
+    complete: bool,
+    /// The MQTT Message ID
+    msg_id: i16,
+    /// The return/error code for the action (zero is success)
+    ret_code: i32,
+    /// The error message (if any)
+    err_msg: String,
+}
+
+
+/// A `Token` is a mechanism for tracking the progress of an asynchronous
+/// operation.
+pub struct Token {
+    // Mutex guards: (done, ret, msgid)
+    lock: Mutex<TokenData>,
+    // Signal for when the state changes
+    cv: Condvar,
+    // Pointer to the client that created the token.
+    // This is only guaranteed valid until the end of the callback
+    cli: *const AsyncClient,
+    // User callback for successful completion of the async action
+    on_success: Option<Box<SuccessCallback>>,
+    // User callback for failed completion of the async action
+    on_failure: Option<Box<FailureCallback>>,
+    // The message (valid only for "delivery" tokens)
+    pub(crate) msg: Option<Message>,
+}
+
+impl Token {
+    /// Creates a new, unsignaled Token.
+    pub fn new() -> Token {
+        Token {
+            lock: Mutex::new(TokenData {
+                complete: false,
+                msg_id: 0,
+                ret_code: 0,
+                err_msg: "".to_string(),
+            }),
+            cv: Condvar::new(),
+            cli: ptr::null(),
+            on_success: None,
+            on_failure: None,
+            msg: None
+        }
+    }
+
+    /// Creates a new, un-signaled delivery Token.
+    /// This is a token which tracks delivery of a message.
+    pub fn from_message(msg: Message) -> Token {
+        Token {
+            lock: Mutex::new(TokenData {
+                complete: false,
+                msg_id: msg.cmsg.msgid as i16,
+                ret_code: 0,
+                err_msg: "".to_string(),
+            }),
+            cv: Condvar::new(),
+            cli: ptr::null(),
+            on_success: None,
+            on_failure: None,
+            msg: Some(msg),
+        }
+    }
+
+    /// Creates a new, un-signaled Token with callbacks.
+    pub fn from_client<FS,FF>(cli: *const AsyncClient,
+                              success_cb: FS,
+                              failure_cb: FF) -> Token
+        where FS: FnMut(&AsyncClient, u16) + 'static,
+              FF: FnMut(&AsyncClient, u16,i32) + 'static
+    {
+        Token {
+            lock: Mutex::new(TokenData {
+                complete: false,
+                msg_id: 0,
+                ret_code: 0,
+                err_msg: "".to_string(),
+            }),
+            cv: Condvar::new(),
+            cli: cli,
+            on_success: Some(Box::new(success_cb)),
+            on_failure: Some(Box::new(failure_cb)),
+            msg: None
+        }
+    }
+
+    /// Creates a new Token signaled with an error.
+    pub fn from_error(rc: i32) -> Token {
+        Token {
+            lock: Mutex::new(TokenData {
+                complete: true,
+                msg_id: 0,
+                ret_code: rc,
+                err_msg: String::from(Token::error_msg(rc)),
+            }),
+            cv: Condvar::new(),
+            cli: ptr::null(),
+            on_success: None,
+            on_failure: None,
+            msg: None
+        }
+    }
+
+    // Callback from the C library for when an async operation succeeds.
+    pub(crate) unsafe extern "C" fn on_success(context: *mut c_void, rsp: *mut ffi::MQTTAsync_successData) {
+        debug!("Token success! {:?}, {:?}", context, rsp);
+        if context.is_null() {
+            return
+        }
+        let msgid = if !rsp.is_null() { (*rsp).token as u16 } else { 0 };
+        let tokptr = context as *mut Token;
+        let tok = &mut *tokptr;
+        tok.on_complete(&*tok.cli, msgid, 0, "".to_string());
+        let _ = Arc::from_raw(tokptr);
+    }
+
+    // Callback from the C library when an async operation fails.
+    pub(crate) unsafe extern "C" fn on_failure(context: *mut c_void, rsp: *mut ffi::MQTTAsync_failureData) {
+        warn!("Token failure! {:?}, {:?}", context, rsp);
+        if context.is_null() {
+            return
+        }
+        let mut msgid = 0;
+        let mut rc = -1;
+        let mut msg = "Error".to_string();
+
+        if !rsp.is_null() {
+            msgid = (*rsp).token as u16;
+            rc = if (*rsp).code == 0 { -1i32 } else { (*rsp).code as i32 };
+
+            if !(*rsp).message.is_null() {
+                if let Ok(cmsg) = CStr::from_ptr((*rsp).message).to_str() {
+                    debug!("Token failure message: {:?}", cmsg);
+                    msg = cmsg.to_string();
+                }
+            }
+        }
+
+        if msg.is_empty() {
+            let emsg = Token::error_msg(rc);
+            msg = emsg.to_string();
+        }
+
+        let tokptr = context as *mut Token;
+        let tok = &mut *tokptr;
+        // TODO: Check client null?
+        tok.on_complete(&*tok.cli, msgid, rc, msg);
+        let _ = Arc::from_raw(tokptr);
+    }
+
+    // Callback function to update the token when the action completes.
+    pub(crate) fn on_complete(&mut self, cli: &AsyncClient, msgid: u16, rc: i32, msg: String) {
+        debug!("Token completed with code: {}", rc);
+        {
+            let mut retv = self.lock.lock().unwrap();
+            (*retv).complete = true;
+            (*retv).ret_code = rc;
+            (*retv).err_msg = msg;
+        }
+        if rc == 0 {
+            if let Some(ref mut cb) = self.on_success {
+                trace!("Invoking Token::on_success callback");
+                cb(cli, msgid);
+            }
+        }
+        else {
+            if let Some(ref mut cb) = self.on_failure {
+                trace!("Invoking Token::on_failure callback");
+                cb(cli, msgid, rc);
+            }
+        }
+        self.cv.notify_all();
+    }
+
+    // Gets the string associated with the error code from the C lib.
+    pub(crate) fn error_msg(rc: i32) -> &'static str {
+        match rc {
+            ffi::MQTTASYNC_FAILURE => "General failure",
+            ffi::MQTTASYNC_PERSISTENCE_ERROR /* -2 */ => "Persistence error",
+            ffi::MQTTASYNC_DISCONNECTED => "Client disconnected",
+            ffi::MQTTASYNC_MAX_MESSAGES_INFLIGHT => "Maximum inflight messages",
+            ffi::MQTTASYNC_BAD_UTF8_STRING => "Bad UTF8 string",
+            ffi::MQTTASYNC_NULL_PARAMETER => "NULL Parameter",
+            ffi::MQTTASYNC_TOPICNAME_TRUNCATED => "Topic name truncated",
+            ffi::MQTTASYNC_BAD_STRUCTURE => "Bad structure",
+            ffi::MQTTASYNC_BAD_QOS => "Bad QoS",
+            ffi::MQTTASYNC_NO_MORE_MSGIDS => "No more message ID's",
+            ffi::MQTTASYNC_OPERATION_INCOMPLETE => "Operation incomplete",
+            ffi::MQTTASYNC_MAX_BUFFERED_MESSAGES => "Max buffered messages",
+            ffi::MQTTASYNC_SSL_NOT_SUPPORTED => "SSL not supported by Paho C library",
+             _ => "",
+        }
+    }
+
+
+    /// Sets the message ID for the token
+    pub(crate) fn set_msgid(&self, msg_id: i16) {
+        let mut retv = self.lock.lock().unwrap();
+        (*retv).msg_id = msg_id;
+    }
+
+
+    /// Blocks the caller until the asynchronous operation has completed.
+    pub fn wait(&self) -> MqttResult<()> {
+        let mut retv = self.lock.lock().unwrap();
+
+        // As long as the 'done' value inside the `Mutex` is false, we wait.
+        while !(*retv).complete {
+            retv = self.cv.wait(retv).unwrap();
+        }
+
+        let rc = (*retv).ret_code;
+        debug!("Token completed: {}", rc);
+        if rc != 0 {
+            let msg = Token::error_msg(rc);
+            fail!((ErrorKind::General, rc, "Error", msg));
+        }
+        Ok(())
+    }
+
+    /// Blocks the caller a limited amount of time waiting for the
+    /// asynchronous operation to complete.
+    pub fn wait_for(&self, dur: Duration) -> MqttResult<()> {
+        let mut retv = self.lock.lock().unwrap();
+
+        while !(*retv).complete {
+            let result = self.cv.wait_timeout(retv, dur).unwrap();
+
+            if result.1.timed_out() {
+                fail!(::std::io::Error::new(::std::io::ErrorKind::TimedOut, "Timed out"));
+            }
+            retv = result.0;
+        }
+
+        let rc = (*retv).ret_code;
+        debug!("Timed token completed: {}", rc);
+        if rc != 0 {
+            let msg = Token::error_msg(rc);
+            fail!((ErrorKind::General, rc, "Error", msg));
+        }
+
+        Ok(())
+    }
+}
+
+/// `Token` specificly for a message delivery operation.
+/// Originally this was a distinct object, but the implementation was
+/// absorbed into a standard `Token`.
+pub type DeliveryToken = Token;
+
+
+/////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    //use super::*;
+
+    // Makes sure than when a client is moved, the inner struct stayes at
+    // the same address (on the heap) since that inner struct is used as
+    // the context pointer for callbacks
+    // GitHub Issue #17
+    #[test]
+    fn test_ok() {
+        assert!(true);
+    }
+}
+

--- a/src/topic.rs
+++ b/src/topic.rs
@@ -21,8 +21,6 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::sync::{Arc};
-
 use async_client::{AsyncClient};
 use token::{DeliveryToken};
 use message::Message;
@@ -91,7 +89,7 @@ impl<'a> Topic<'a>
     ///
     /// `payload` The payload of the message
     ///
-    pub fn publish<V>(&self, payload: V) -> Arc<DeliveryToken>
+    pub fn publish<V>(&self, payload: V) -> DeliveryToken
         where V: Into<Vec<u8>>
     {
         // OPTIMIZE: This could be more efficient.

--- a/src/topic.rs
+++ b/src/topic.rs
@@ -23,7 +23,8 @@
 
 use std::sync::{Arc};
 
-use async_client::{AsyncClient,DeliveryToken};
+use async_client::{AsyncClient};
+use token::{DeliveryToken};
 use message::Message;
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Support for Futures

- `Token` now implements the Future trait for the async client's _connect()_, _disconnect()_, _publish()_, etc
- `AsyncClient::get_stream()` returns a streaming input object (a future mpsc Receiver)