### PR TITLE
Move env_logger to [dev-dependencies]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,12 @@ libc = "0.2"
 futures = "0.1"
 futures-timer = "0.1"
 log = "0.4"
-env_logger = "0.6"
+
+[dev-dependencies]
+env_logger = "0.7"
 
 [features]
 default = ["bundled", "ssl"]
 bundled = ["paho-mqtt-sys/bundled"]
 build_bindgen = ["paho-mqtt-sys/build_bindgen"]
 ssl = ["paho-mqtt-sys/ssl"]
-


### PR DESCRIPTION
Move env_logger to [dev-dependencies] since it is only used for
examples.

Signed-off-by: Tobias Dubois <tobias.dubois@gmail.com>