### PR TITLE
Transition to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "paho-mqtt"
 version = "0.6.0"
+edition = "2018"
 authors = ["Frank Pagliughi <fpagliughi@mindspring.com>"]
 homepage = "https://github.com/eclipse/paho.mqtt.rust"
 repository = "https://github.com/eclipse/paho.mqtt.rust"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository contains the source code for the [Eclipse Paho](http://eclipse.org/paho) MQTT Rust client library on memory-managed operating systems such as Linux/Posix, Mac, and Windows.
 
-The Rust crate is a safe wrapper around the Paho C Library. 
+The Rust crate is a safe wrapper around the Paho C Library.
 
 Most development and deployment has being done on Linux. Please let us know about any success or failure on other systems.
 
@@ -18,7 +18,7 @@ The initial version of this crate is a wrapper for the Paho C library, similar t
     - WebSockets
 - QoS 0, 1, and 2
 - Last Will and Testament (LWT)
-- Message Persistence 
+- Message Persistence
     - File or memory persistence
     - User-defined persistence (including example for Redis)
 - Automatic Reconnect
@@ -43,7 +43,7 @@ To keep up with the latest announcements for this project, follow:
 
 ### New Features in v0.6
 
-The v0.6 release added support for Futures and cleaned up the internal implementation of the library. 
+The v0.6 release added support for Futures and cleaned up the internal implementation of the library.
 
 - **Futures support:**
     - Compatible with the [Rust Futures](https://docs.rs/futures/0.1.25/futures/) library v0.1
@@ -53,16 +53,16 @@ The v0.6 release added support for Futures and cleaned up the internal implement
     - New examples of a publisher and subscriber implemented with futures.
 
 - **Server Responses**
-    - There are now several different types of tokens corresponding to different requests for which the server can return a response: _ConnectToken_, _DeliveryToken_, _SubscribeToken_, etc. 
+    - There are now several different types of tokens corresponding to different requests for which the server can return a response: _ConnectToken_, _DeliveryToken_, _SubscribeToken_, etc.
     - Tokens now track the type of request and get the server response upon completion. This is the Futures _Item_ type for the token.
     - In particular this is useful for connecting subscribers. The app can now determine if a persistent session is already present, and only needs to subscribe if not.
-    
+
 - **Send and Sync Traits**
     - The clients are now marked as _Send_ and _Sync_
     - The _Token_ types are _Send_
     - Most of the option types are _Send_ and _Sync_
     - _AsyncClient_ and _Token_ objects are now just _Arc_ wrappers around inner structs making it easy to clone and pass references around.
-    
+
 - **Internal Cleanup**
     - Updated to wrap Paho C v1.3.1 which has a number of important bug fixes.
     - Moved `Tokens` into their own source file.
@@ -81,7 +81,7 @@ The library is a standard Rust "crate" using the _Cargo_ build tool. It uses the
 
 `$ cargo build`
 
-Builds the library, and also builds the *-sys* subcrate and the bundled Paho C library. It includes SSL, as it is defined as a default feature. 
+Builds the library, and also builds the *-sys* subcrate and the bundled Paho C library. It includes SSL, as it is defined as a default feature.
 
 `$ cargo build --examples`
 
@@ -115,7 +115,7 @@ These are chosen with cargo features, explained below.
 This is the default:
 
     $ cargo build
-    
+
 This will initialize and update the C library sources from Git, then use the _cmake_ crate to build the static version of the C library, and link it in. By default, the build will use the pre-generated bindings in _bindings/bindings_paho_mqtt_X_Y_Z.rs_, where _X_Y_Z_ is the currently supported library version.
 
 The defalut features for the build are: ["bundled", "ssl"]
@@ -123,7 +123,7 @@ The defalut features for the build are: ["bundled", "ssl"]
 When building the bundled libraries, the bindings can also be regenerated at build-time. This is especially useful when building on uncommon/untested platforms to ensure proper bindings for that system. This is done adding the "build_bindgen" feature:
 
     $ cargo build --features "build_bindgen"
-    
+
 In this case it will generate bindings based on the header files in the bundled C repository.
 
 The cached versions of the bindings were created on an x86_64 PC running Linux. When compiling on a different machine or cross-compiling, it is recommended to use "build_bindgen" to regenerate the bindings for that target.
@@ -138,16 +138,16 @@ The crate can build the bundled Paho C library without secure sockets:
 
 #### Linking to an exteral Paho C library
 
-The crate can generate bindings to a copy of the Paho C library in a different location in the local file system, and link to that library. 
+The crate can generate bindings to a copy of the Paho C library in a different location in the local file system, and link to that library.
 
     $ cargo build --no-default-features --features "build_bindgen,ssl"
 
-The "ssl" feature can be omitted if it is not desired. 
+The "ssl" feature can be omitted if it is not desired.
 
 The location of the C library is specified through an environment variable:
 
     PAHO_MQTT_C_DIR= ...path to install directory...
-    
+
 It's assumed that the headers are in an _include/_ directory below the one specified, and the library is in _lib/_ under it. This would be the case with a normal install.
 
 Alternately, this can be expressed with individual environment variables for each of the header and library directories:
@@ -159,7 +159,7 @@ In this case, the headers and library can be found independently. This was neces
 
 #### Linking to an installed Paho C library
 
-If the correct version of the Paho C library is expected to be installed on the target system, the simplest solution is to use the pre-generated bindings and specify a link to the shared paho C library. 
+If the correct version of the Paho C library is expected to be installed on the target system, the simplest solution is to use the pre-generated bindings and specify a link to the shared paho C library.
 
     $ cargo build --no-default-features --features "ssl"
 
@@ -184,7 +184,7 @@ export LIBCLANG_PATH=/usr/lib/llvm-3.9/lib
 
 ### Cross-Compiling
 
-I was pleasently surprised to discover that the *cmake* crate automatically handles cross-compiling libraries. You'll need a C cross-compiler installed on your system. See here for more info about cross-compiling Rust, in general: 
+I was pleasently surprised to discover that the *cmake* crate automatically handles cross-compiling libraries. You'll need a C cross-compiler installed on your system. See here for more info about cross-compiling Rust, in general:
 
 https://github.com/japaric/rust-cross
 
@@ -236,9 +236,8 @@ export MQTT_C_CLIENT_TRACE_LEVEL=PROTOCOL
 Several small sample applications can be found in the _examples_ directory. Here is what a small MQTT publisher might look like:
 
 ```
+use paho_mqtt as mqtt;
 use std::process;
-
-extern crate paho_mqtt as mqtt;
 
 fn main() {
     // Create a client & define connect options

--- a/examples/async_persist_publish.rs
+++ b/examples/async_persist_publish.rs
@@ -28,12 +28,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate futures;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
-extern crate paho_mqtt as mqtt;
-
+use log::{trace, debug};
+use paho_mqtt as mqtt;
 use std::process;
 use std::collections::HashMap;
 use futures::Future;

--- a/examples/async_publish.rs
+++ b/examples/async_publish.rs
@@ -24,11 +24,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate futures;
-extern crate log;
-extern crate env_logger;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{env, process};
 use futures::Future;
 

--- a/examples/async_publish_time.rs
+++ b/examples/async_publish_time.rs
@@ -29,11 +29,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate futures;
-extern crate log;
-extern crate env_logger;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{env, process, thread};
 use std::time::{SystemTime, Duration};
 use futures::Future;
@@ -91,4 +88,3 @@ fn main() {
         }
     }
 }
-

--- a/examples/async_subscribe.rs
+++ b/examples/async_subscribe.rs
@@ -32,10 +32,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate log;
-extern crate env_logger;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{env, process, thread};
 use std::time::Duration;
 
@@ -130,4 +128,3 @@ fn main() {
     // Hitting ^C will exit the app and cause the broker to publish the
     // LWT message since we're not disconnecting cleanly.
 }
-

--- a/examples/futures_consume.rs
+++ b/examples/futures_consume.rs
@@ -34,14 +34,10 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate log;
-extern crate env_logger;
-extern crate futures;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{env, process};
 use std::time::Duration;
-
 use futures::{Future, Stream};
 use futures::future::{Either, ok};
 
@@ -132,4 +128,3 @@ fn main() {
     // Hitting ^C will exit the app and cause the broker to publish
     // the LWT message since we're not disconnecting cleanly.
 }
-

--- a/examples/futures_publish.rs
+++ b/examples/futures_publish.rs
@@ -24,11 +24,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate futures;
-extern crate log;
-extern crate env_logger;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{env, process};
 use futures::Future;
 
@@ -60,4 +57,3 @@ fn main() {
             mqtt::ServerResponse::None
         });
 }
-

--- a/examples/futures_roundtrip.rs
+++ b/examples/futures_roundtrip.rs
@@ -29,11 +29,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate log;
-extern crate env_logger;
-extern crate futures;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{process};
 use std::time::Duration;
 use futures::{Future, Stream};
@@ -100,4 +97,3 @@ fn main() {
         process::exit(3);
     });
 }
-

--- a/examples/ssl_publish.rs
+++ b/examples/ssl_publish.rs
@@ -36,11 +36,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate futures;
-extern crate log;
-extern crate env_logger;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{time, env, process};
 use futures::Future;
 
@@ -120,4 +117,3 @@ fn main() {
     let tok = cli.disconnect(disconn_opts);
     tok.wait().unwrap();
 }
-

--- a/examples/sync_consume.rs
+++ b/examples/sync_consume.rs
@@ -32,10 +32,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate log;
-extern crate env_logger;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{env, process, thread};
 use std::time::Duration;
 
@@ -147,4 +145,3 @@ fn main() {
     }
     println!("Exiting");
 }
-

--- a/examples/sync_publish.rs
+++ b/examples/sync_publish.rs
@@ -26,10 +26,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate log;
-extern crate env_logger;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{env, process};
 use std::time::Duration;
 

--- a/examples/topic_publish.rs
+++ b/examples/topic_publish.rs
@@ -26,11 +26,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate futures;
-extern crate log;
-extern crate env_logger;
-extern crate paho_mqtt as mqtt;
 
+use paho_mqtt as mqtt;
 use std::{env, process};
 use futures::Future;
 
@@ -74,4 +71,3 @@ fn main() {
 	let tok = cli.disconnect(None);
 	tok.wait().unwrap();
 }
-

--- a/paho-mqtt-sys/build.rs
+++ b/paho-mqtt-sys/build.rs
@@ -275,4 +275,3 @@ mod build {
         bindings::place_bindings(&Path::new(&inc_dir));
     }
 }
-

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -30,10 +30,8 @@
 //! wait for the connection to complete.
 //!
 //! ```
-//! extern crate futures;
-//! extern crate paho_mqtt as mqtt;
-//!
 //! use futures::future::Future;
+//! use paho_mqtt as mqtt;
 //!
 //! let cli = mqtt::AsyncClient::new("tcp://localhost:1883").unwrap();
 //!
@@ -53,18 +51,18 @@ use std::sync::{Arc, Mutex};
 use std::ffi::{CString, CStr};
 use std::os::raw::{c_void, c_char, c_int};
 
-use ffi;
+use crate::ffi;
 
-use create_options::{CreateOptions,PersistenceType};
-use connect_options::ConnectOptions;
-use disconnect_options::{DisconnectOptions,DisconnectOptionsBuilder};
-use response_options::ResponseOptions;
-use message::Message;
-use token::{Token, ConnectToken, DeliveryToken, SubscribeToken, SubscribeManyToken};
-use client_persistence::UserPersistence;
-use errors;
-use errors::{MqttResult, ErrorKind};
-use string_collection::{StringCollection};
+use crate::create_options::{CreateOptions,PersistenceType};
+use crate::connect_options::ConnectOptions;
+use crate::disconnect_options::{DisconnectOptions,DisconnectOptionsBuilder};
+use crate::response_options::ResponseOptions;
+use crate::message::Message;
+use crate::token::{Token, ConnectToken, DeliveryToken, SubscribeToken, SubscribeManyToken};
+use crate::client_persistence::UserPersistence;
+use crate::errors;
+use crate::errors::{MqttResult, ErrorKind};
+use crate::string_collection::{StringCollection};
 
 /////////////////////////////////////////////////////////////////////////////
 // AsynClient
@@ -844,7 +842,7 @@ mod tests {
     use super::*;
     use std::thread;
     use std::sync::Arc;
-    use create_options::{CreateOptionsBuilder};
+    use crate::create_options::{CreateOptionsBuilder};
     use futures::Future;
 
     // Makes sure than when a client is moved, the inner struct stayes at
@@ -924,4 +922,3 @@ mod tests {
         let _ = thr.join().unwrap();
     }
 }
-

--- a/src/client.rs
+++ b/src/client.rs
@@ -30,12 +30,12 @@
 use std::time::Duration;
 use std::sync::mpsc;
 
-use async_client::AsyncClient;
-use create_options::CreateOptions;
-use connect_options::ConnectOptions;
-use disconnect_options::DisconnectOptions;
-use message::Message;
-use errors::MqttResult;
+use crate::async_client::AsyncClient;
+use crate::create_options::CreateOptions;
+use crate::connect_options::ConnectOptions;
+use crate::disconnect_options::DisconnectOptions;
+use crate::message::Message;
+use crate::errors::MqttResult;
 
 /////////////////////////////////////////////////////////////////////////////
 // Client

--- a/src/client_persistence.rs
+++ b/src/client_persistence.rs
@@ -1,5 +1,5 @@
 // client_persistence.rs
-// 
+//
 // This file is part of the Eclipse Paho MQTT Rust Client library.
 //
 
@@ -19,15 +19,15 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-extern crate libc;
+use libc;
 
 use std::{ptr, slice, mem};
 use std::ffi::{CString, CStr};
 use std::os::raw::{c_void, c_char, c_int};
 
-use ffi;
+use crate::ffi;
 
-use errors::MqttResult;
+use crate::errors::MqttResult;
 
 // TODO: Should we have a specific PersistenceResult/Error?
 
@@ -348,4 +348,3 @@ mod tests {
     }
     */
 }
-

--- a/src/connect_options.rs
+++ b/src/connect_options.rs
@@ -24,17 +24,17 @@
 //! This contains the structures to define the options for connecting to the
 //! MQTT broker/server.
 
-use ffi;
+use crate::ffi;
 use std::ptr;
 use std::time::Duration;
 use std::ffi::CString;
 use std::os::raw::c_int;
 
-use token::{ConnectToken, Token, TokenInner};
-use message::Message;
-use will_options::WillOptions;
-use ssl_options::SslOptions;
-use string_collection::StringCollection;
+use crate::token::{ConnectToken, Token, TokenInner};
+use crate::message::Message;
+use crate::will_options::WillOptions;
+use crate::ssl_options::SslOptions;
+use crate::string_collection::StringCollection;
 
 /// The default version to connect with.
 /// First try v3.1.1, and if that fails, try v3.1
@@ -405,7 +405,7 @@ mod tests {
     use super::*;
     use std::thread;
     use std::ffi::{CStr};
-    use ssl_options::SslOptionsBuilder;
+    use crate::ssl_options::SslOptionsBuilder;
     use std::os::raw::c_char;
 
     // Identifier fo a C connect options struct

--- a/src/create_options.rs
+++ b/src/create_options.rs
@@ -22,8 +22,8 @@
 
 use std::fmt;
 
-use ffi;
-use client_persistence::ClientPersistence;
+use crate::ffi;
+use crate::client_persistence::ClientPersistence;
 
 /*
 Remember the C constants (c_uint)
@@ -43,7 +43,7 @@ pub enum PersistenceType {
 }
 
 impl fmt::Debug for PersistenceType {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match *self {
 			PersistenceType::File => write!(f, "File"),
 			PersistenceType::None => write!(f, "None"),
@@ -57,7 +57,7 @@ impl fmt::Debug for PersistenceType {
 /////////////////////////////////////////////////////////////////////////////
 
 /// The options for creating an MQTT client.
-/// This can be constructed using a 
+/// This can be constructed using a
 /// [CreateOptionsBuilder](struct.CreateOptionsBuilder.html).
 #[derive(Debug)]
 pub struct CreateOptions {
@@ -133,13 +133,13 @@ impl Default for CreateOptions {
 /// # Examples
 ///
 /// ```
-/// extern crate paho_mqtt as mqtt;
-/// 
+/// use paho_mqtt as mqtt;
+///
 /// let opts = mqtt::CreateOptionsBuilder::new()
 ///                    .server_uri("tcp://localhost:1883")
 ///                    .client_id("client1")
 ///                    .finalize();
-/// 
+///
 /// let cli = mqtt::AsyncClient::new(opts).unwrap();
 /// ```
 
@@ -162,12 +162,12 @@ impl CreateOptionsBuilder {
 	}
 
 	/// Sets the the URI to the MQTT broker.
-	/// Alternately, the application can specify multiple servers via the 
+	/// Alternately, the application can specify multiple servers via the
 	/// connect options.
 	///
 	/// # Arguments
 	///
-	/// `server_uri` The URI string to specify the server in the form 
+	/// `server_uri` The URI string to specify the server in the form
 	///              _protocol://host:port_, where the protocol can be
 	///              _tcp_ or _ssl_, and the host can be an IP address
 	///              or domain name.
@@ -179,16 +179,16 @@ impl CreateOptionsBuilder {
 
 	/// Sets the client identifier string that is sent to the server.
 	/// The client ID is a unique name to identify the client to the server,
-	/// which can be used if the client desires the server to hold state 
+	/// which can be used if the client desires the server to hold state
 	/// about the session. If the client requests a clean sesstion, this can
 	/// be an empty string.
-	/// 
-	/// The broker is required to honor a client ID of up to 23 bytes, but 
+	///
+	/// The broker is required to honor a client ID of up to 23 bytes, but
 	/// could honor longer ones, depending on the broker.
-	/// 
-	/// Note that if this is an empty string, the clean session parameter 
+	///
+	/// Note that if this is an empty string, the clean session parameter
 	/// *must* be set to _true_.
-	/// 
+	///
 	/// # Arguments
 	///
 	/// `client_id` A UTF-8 string identifying the client to the server.
@@ -201,7 +201,7 @@ impl CreateOptionsBuilder {
 
 	/// Sets the type of persistence used by the client.
 	/// The default is for the library to automatically use file persistence,
-	/// although this can be turned off by specify `None` for a more 
+	/// although this can be turned off by specify `None` for a more
 	/// performant, though possibly less reliable system.
 	///
 	/// # Arguments
@@ -214,15 +214,15 @@ impl CreateOptionsBuilder {
 	}
 
 	/// Sets a user-defined persistence store.
-	/// This sets the persistence to use a custom one defined by the 
-	/// application. This can be anything that implements the 
+	/// This sets the persistence to use a custom one defined by the
+	/// application. This can be anything that implements the
 	/// `ClientPersistence` trait.
 	///
 	/// # Arguments
 	///
 	/// `persist` An application-defined custom persistence store.
 	///
-	pub fn user_persistence<T>(mut self, persistence: T) -> CreateOptionsBuilder 
+	pub fn user_persistence<T>(mut self, persistence: T) -> CreateOptionsBuilder
 			where T: ClientPersistence + 'static
 	{
 		let persistence: Box<Box<dyn ClientPersistence>> = Box::new(Box::new(persistence));
@@ -232,7 +232,7 @@ impl CreateOptionsBuilder {
 
 	/// Sets the maximum number of messages that can be buffered for delivery
 	/// when the client is off-line.
-	/// The client has limited support for bufferering messages when the 
+	/// The client has limited support for bufferering messages when the
 	/// client is temporarily disconnected. This specifies the maximum number
 	/// of messages that can be buffered.
 	///
@@ -367,5 +367,3 @@ mod tests {
 		assert_eq!(MAX_BUF_MSGS, opts.copts.maxBufferedMessages);
 	}
 }
-
-

--- a/src/disconnect_options.rs
+++ b/src/disconnect_options.rs
@@ -25,10 +25,10 @@
 //! This contains the structures to define the options for disconnecting from
 //! the MQTT broker/server.
 
-use ffi;
+use crate::ffi;
 use std::time::Duration;
 
-use token::{Token, TokenInner};
+use crate::token::{Token, TokenInner};
 
 /// The collection of options for disconnecting from the client.
 #[derive(Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::io;
 use std::str::Utf8Error;
 
-use ffi;
+use crate::ffi;
 
 // Gets the string associated with the error code from the C lib.
 pub fn error_message(rc: i32) -> &'static str {
@@ -169,7 +169,7 @@ impl error::Error for MqttError {
 }
 
 impl fmt::Display for MqttError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self.repr {
             ErrorRepr::WithDescription(_, _err, desc) => desc.fmt(f),
             ErrorRepr::WithDescriptionAndDetail(_, err_code, desc, ref detail) => {
@@ -188,7 +188,7 @@ impl fmt::Display for MqttError {
 }
 
 impl fmt::Debug for MqttError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Display::fmt(self, f)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,27 +32,25 @@
 // Temporary
 #![allow(dead_code)]
 
-extern crate futures;
-extern crate futures_timer;
 
 #[macro_use]
 extern crate log;
 
 extern crate paho_mqtt_sys as ffi;
 
-pub use async_client::*;        //{AsyncClient, AsyncClientBuilder};
-pub use client::*;              //{Client, ClientBuilder};
-pub use create_options::*;      //{CreateOptions, CreateOptionsBuilder};
-pub use connect_options::*;     //{ConnectOptions, ConnectOptionsBuilder, MQTT_VERSION_3_1_1, ...};
-pub use will_options::*;        //{WillOptions, WillOptionsBuilder};
-pub use ssl_options::*;         //{SslOptions, SslOptionsBuilder};
-pub use disconnect_options::*;  //{DisconnectOptions, DisconnectOptionsBuilder};
-pub use response_options::*;    //{ResponseOptions};
-pub use message::*;             //{Message, MessageBuilder};
-pub use token::*;               //{Token}
-pub use topic::*;               //{Topic}
-pub use client_persistence::*;
-pub use errors::*;              //{MqttResult, MqttError, ErrorKind};
+pub use crate::async_client::*;        //{AsyncClient, AsyncClientBuilder};
+pub use crate::client::*;              //{Client, ClientBuilder};
+pub use crate::create_options::*;      //{CreateOptions, CreateOptionsBuilder};
+pub use crate::connect_options::*;     //{ConnectOptions, ConnectOptionsBuilder, MQTT_VERSION_3_1_1, ...};
+pub use crate::will_options::*;        //{WillOptions, WillOptionsBuilder};
+pub use crate::ssl_options::*;         //{SslOptions, SslOptionsBuilder};
+pub use crate::disconnect_options::*;  //{DisconnectOptions, DisconnectOptionsBuilder};
+pub use crate::response_options::*;    //{ResponseOptions};
+pub use crate::message::*;             //{Message, MessageBuilder};
+pub use crate::token::*;               //{Token}
+pub use crate::topic::*;               //{Topic}
+pub use crate::client_persistence::*;
+pub use crate::errors::*;              //{MqttResult, MqttError, ErrorKind};
 
 //pub mod mqtt;
 mod macros;
@@ -103,4 +101,3 @@ pub mod string_collection;
 #[cfg(test)]
 mod tests {
 }
-

--- a/src/message.rs
+++ b/src/message.rs
@@ -26,7 +26,7 @@ use std::convert::From;
 use std::borrow::Cow;
 use std::fmt;
 
-use ffi;
+use crate::ffi;
 
 /// A `Message` represents all the information passed in an MQTT PUBLISH
 /// packet.
@@ -132,7 +132,7 @@ impl Message {
     /// return a `Cow::Borrowed([&str])` with the the corresponding `[&str]` slice.
     /// Otherwise, it will replace any invalid UTF-8 sequences with U+FFFD
     /// REPLACEMENT CHARACTER and return a `Cow::Owned(String)` with the result.
-    pub fn payload_str(&self) -> Cow<str> {
+    pub fn payload_str(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(&self.payload)
     }
 
@@ -198,7 +198,7 @@ impl<'a, 'b> From<(&'a str, &'b [u8], i32, bool)> for Message {
 
 impl fmt::Display for Message
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let topic = match self.topic.as_c_str().to_str() {
             Ok(s) => s,
             Err(_) => return Err(fmt::Error),

--- a/src/response_options.rs
+++ b/src/response_options.rs
@@ -22,8 +22,8 @@
 
 //! Response options for the Paho MQTT Rust client library.
 
-use ffi;
-use token::{Token, TokenInner};
+use crate::ffi;
+use crate::token::{Token, TokenInner};
 
 /// The collection of options for responses coming back to the client.
 #[derive(Debug)]
@@ -66,7 +66,7 @@ impl ResponseOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use token::{Token};
+    use crate::token::{Token};
 
     #[test]
     fn test_new() {

--- a/src/ssl_options.rs
+++ b/src/ssl_options.rs
@@ -23,7 +23,7 @@ use std::ptr;
 use std::ffi::{CString};
 use std::os::raw::{c_char};
 
-use ffi;
+use crate::ffi;
 
 // Implementation note:
 // The C library seems to require the SSL Options struct to provide valid

--- a/src/token.rs
+++ b/src/token.rs
@@ -41,12 +41,12 @@ use futures::task;
 use futures::task::Task;
 use futures_timer::FutureExt;
 
-use ffi;
+use crate::ffi;
 
-use async_client::{AsyncClient};
-use message::Message;
-use errors;
-use errors::{MqttResult, MqttError};
+use crate::async_client::{AsyncClient};
+use crate::message::Message;
+use crate::errors;
+use crate::errors::{MqttResult, MqttError};
 
 /////////////////////////////////////////////////////////////////////////////
 // TokenData

--- a/src/topic.rs
+++ b/src/topic.rs
@@ -21,9 +21,9 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use async_client::{AsyncClient};
-use token::{DeliveryToken};
-use message::Message;
+use crate::async_client::{AsyncClient};
+use crate::token::{DeliveryToken};
+use crate::message::Message;
 
 /////////////////////////////////////////////////////////////////////////////
 //                              Topic

--- a/src/will_options.rs
+++ b/src/will_options.rs
@@ -33,9 +33,9 @@ use std::ffi::CString;
 use std::os::raw::c_void;
 use std::borrow::Cow;
 
-use ffi;
+use crate::ffi;
 
-use message::Message;
+use crate::message::Message;
 
 /// The options for the Last Will and Testament (LWT).
 /// This defines a message that is registered with the the server at the time
@@ -48,7 +48,7 @@ use message::Message;
 /// encouraged to just create a `Message` object and use it when building
 /// `ConnectOptions`:
 /// ```
-/// extern crate paho_mqtt as mqtt;
+/// use paho_mqtt as mqtt;
 ///
 /// let lwt = mqtt::Message::new("lwt", "disconnected", 1);
 /// let opts = mqtt::ConnectOptionsBuilder::new().will_message(lwt).finalize();
@@ -137,7 +137,7 @@ impl WillOptions {
 
     /// Gets the payload of the message as a string.
     /// Note that this clones the payload.
-    pub fn payload_str(&self) -> Cow<str> {
+    pub fn payload_str(&self) -> Cow<'_, str> {
         String::from_utf8_lossy(&self.payload)
     }
 
@@ -206,7 +206,7 @@ impl From<Message> for WillOptions {
 mod tests {
     use super::*;
     use std::os::raw::{c_char};
-    use message::MessageBuilder;
+    use crate::message::MessageBuilder;
 
     // The C struct identifier for will options and the supported struct version.
     const STRUCT_ID: [c_char; 4] = [ b'M' as c_char, b'Q' as c_char, b'T' as c_char, b'W' as c_char];
@@ -350,4 +350,3 @@ mod tests {
         assert!(opts.copts.retained != 0);
     }
 }
-


### PR DESCRIPTION
Transition to 2018 edition using:
`cargo fix --edition`
`cargo fix --edition-idioms`
+ some manual fixes

Signed-off-by: Tobias Dubois <tobias.dubois@gmail.com>