### PR TITLE
To fix cannot find -lssl and -lcrypto when cross-compile

### DIFF
--- a/paho-mqtt-sys/build.rs
+++ b/paho-mqtt-sys/build.rs
@@ -205,8 +205,8 @@ mod build {
 
         // Link in the SSL libraries if configured for it.
         if cfg!(feature = "ssl") {
-            println!("cargo:rustc-link-lib=ssl");
-            println!("cargo:rustc-link-lib=crypto");
+            println!("cargo:rustc-link-lib=static=ssl");
+            println!("cargo:rustc-link-lib=static=crypto");
         }
 
         // we add the folder where all the libraries are built to the path search

--- a/paho-mqtt-sys/build.rs
+++ b/paho-mqtt-sys/build.rs
@@ -160,6 +160,7 @@ mod build {
 
         if let Ok(ssl_sp) = env::var("OPENSSL_SEARCH_PATH") {
             cmk_cfg.define("OPENSSL_SEARCH_PATH", format!("{}", ssl_sp));
+            println!("cargo:rustc-link-search=native={}/lib", ssl_sp);
         }
 
         // 'cmk' is a PathBuf to the cmake install directory


### PR DESCRIPTION
rust: 1.39
host: Ubuntu 18.04.3 LTS
target: armv7-unknown-linux-gnueabihf

![图片](https://user-images.githubusercontent.com/6816901/69124679-4d5ac300-0adf-11ea-9701-bb07905b7520.png)
