### PR TITLE
Run `cargo fmt —all` on the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Version 0.7 brings full support for MQTT v5, including:
 - New callback `on_disconnect()` for when the client receives a disconnect packet from the server, complete with a reason code and properties.
 - Example for a simple chat application _(mqttrs_chat)_ using the v5 "No Local" subscription option. The publisher does not get their own messages echoed back to them.
  - Examples for RPC using v5 _Properties_ for _ResponseTopic_ and _CorrelationData:_
-     - A math RPC service/server _(rpc_math_srvr)_ that performs basic operations on a list of numbers. 
+     - A math RPC service/server _(rpc_math_srvr)_ that performs basic operations on a list of numbers.
      - A math RPC client  _(rpc_math_cli)_ that can send requests.
 
 Also:
@@ -35,7 +35,7 @@ Note that v0.7 still targets Futures v0.1 and Rust Edition 2015. Support for asy
 
 ## [v0.6](https://github.com/eclipse/paho.mqtt.rust/compare/v0.5..v0.6) - 2019-10-12
 
-The v0.6 release added support for Futures and cleaned up the internal implementation of the library. 
+The v0.6 release added support for Futures and cleaned up the internal implementation of the library.
 
 - **Futures support:**
     - Compatible with the [Rust Futures](https://docs.rs/futures/0.1.25/futures/) library v0.1
@@ -45,16 +45,16 @@ The v0.6 release added support for Futures and cleaned up the internal implement
     - New examples of a publisher and subscriber implemented with futures.
 
 - **Server Responses**
-    - There are now several different types of tokens corresponding to different requests for which the server can return a response: _ConnectToken_, _DeliveryToken_, _SubscribeToken_, etc. 
+    - There are now several different types of tokens corresponding to different requests for which the server can return a response: _ConnectToken_, _DeliveryToken_, _SubscribeToken_, etc.
     - Tokens now track the type of request and get the server response upon completion. This is the Futures _Item_ type for the token.
     - In particular this is useful for connecting subscribers. The app can now determine if a persistent session is already present, and only needs to subscribe if not.
-    
+
 - **Send and Sync Traits**
     - The clients are now marked as _Send_ and _Sync_
     - The _Token_ types are _Send_
     - Most of the option types are _Send_ and _Sync_
     - _AsyncClient_ and _Token_ objects are now just _Arc_ wrappers around inner structs making it easy to clone and pass references around.
-    
+
 - **Internal Cleanup**
     - Updated to wrap Paho C v1.3.1 which has a number of important bug fixes.
     - Moved `Tokens` into their own source file.
@@ -74,5 +74,3 @@ The v0.6 release added support for Futures and cleaned up the internal implement
 ### Changed
 
 - Updated the library to bundle and use Paho C v1.3.0
-
-

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repository contains the source code for the [Eclipse Paho](http://eclipse.org/paho) MQTT Rust client library on memory-managed operating systems such as Linux/Posix, Mac, and Windows.
 
-The Rust crate is a safe wrapper around the Paho C Library. 
+The Rust crate is a safe wrapper around the Paho C Library.
 
 ## Features
 
@@ -17,7 +17,7 @@ The initial version of this crate is a wrapper for the Paho C library, and inclu
     - WebSockets
 - QoS 0, 1, and 2
 - Last Will and Testament (LWT)
-- Message Persistence 
+- Message Persistence
     - File or memory persistence
     - User-defined key/value persistence (including example for Redis)
 - Automatic Reconnect
@@ -35,7 +35,7 @@ Supports Paho C v1.3.2
 Work has started to move the library to modern Rust, including:
 
 - Upgrade to the 2018 Edition
-- Convert Tokens to implement std Future (i.e. Futures 0.3) and support async/await. 
+- Convert Tokens to implement std Future (i.e. Futures 0.3) and support async/await.
 - Clean up and modernize the error type using _thiserror_ crate.
 
 That should hopefully be complete by late May 2020.
@@ -52,7 +52,7 @@ To keep up with the latest announcements for this project, follow:
 
 ### Unreleased Features and Updates in this Branch
 
-- Upgraded crate to 2018 Edition 
+- Upgraded crate to 2018 Edition
 - Upgraded Tokens to implement Futures 0.3. (async/await compatible!)
 - Error type based on _thiserror_
 - Added some missing/forgotten MQTT v5 support:
@@ -63,7 +63,7 @@ To keep up with the latest announcements for this project, follow:
 - Removed old asynchronous (futures 0.1-style) examples
 - Message and option structs were reimplemented internally with pinned inner data structs.
 - Removed `AsyncClientBuilder`. Use `CreateClientBuilder` instead, possibly with new `create_client()` function.
-- `SslOptions` using `Path` and `PathBuf` for file names in the API instead of `String`. 
+- `SslOptions` using `Path` and `PathBuf` for file names in the API instead of `String`.
 - The reason code returned from the server moved into the `ServerResponse` struct.
 - Added `ConnectResponse` as a struct instead of a tuple for the data returned in CONNACK.
 
@@ -80,7 +80,7 @@ Version 0.7 brings full support for MQTT v5, including:
 - New callback `on_disconnect()` for when the client receives a disconnect packet from the server, complete with a reason code and properties.
 - Example for a simple chat application _(mqttrs_chat)_ using the v5 "No Local" subscription option. The publisher does not get their own messages echoed back to them.
  - Examples for RPC using v5 _Properties_ for _ResponseTopic_ and _CorrelationData:_
-     - A math RPC service/server _(rpc_math_srvr)_ that performs basic operations on a list of numbers. 
+     - A math RPC service/server _(rpc_math_srvr)_ that performs basic operations on a list of numbers.
      - A math RPC client  _(rpc_math_cli)_ that can send requests.
 
 Also:
@@ -98,7 +98,7 @@ The library is a standard Rust "crate" using the _Cargo_ build tool. It uses the
 
 `$ cargo build`
 
-Builds the library, and also builds the *-sys* subcrate and the bundled Paho C library. It includes SSL, as it is defined as a default feature. 
+Builds the library, and also builds the *-sys* subcrate and the bundled Paho C library. It includes SSL, as it is defined as a default feature.
 
 `$ cargo build --examples`
 
@@ -132,7 +132,7 @@ These are chosen with cargo features, explained below.
 This is the default:
 
     $ cargo build
-    
+
 This will initialize and update the C library sources from Git, then use the _cmake_ crate to build the static version of the C library, and link it in. By default, the build will use the pre-generated bindings in _bindings/bindings_paho_mqtt_X_Y_Z.rs_, where _X_Y_Z_ is the currently supported library version.
 
 The defalut features for the build are: ["bundled", "ssl"]
@@ -140,7 +140,7 @@ The defalut features for the build are: ["bundled", "ssl"]
 When building the bundled libraries, the bindings can also be regenerated at build-time. This is especially useful when building on uncommon/untested platforms to ensure proper bindings for that system. This is done adding the "build_bindgen" feature:
 
     $ cargo build --features "build_bindgen"
-    
+
 In this case it will generate bindings based on the header files in the bundled C repository.
 
 The cached versions of the bindings are target-specific. If the pre-generated version doesn't exist for the target, it will need to be generated.
@@ -161,16 +161,16 @@ The crate can also be build without SSL by using `--no-default-features`. For ex
 
 #### Linking to an exteral Paho C library
 
-The crate can generate bindings to a copy of the Paho C library in a different location in the local file system, and link to that library. 
+The crate can generate bindings to a copy of the Paho C library in a different location in the local file system, and link to that library.
 
     $ cargo build --no-default-features --features "build_bindgen,ssl"
 
-The "ssl" feature can be omitted if it is not desired. 
+The "ssl" feature can be omitted if it is not desired.
 
 The location of the C library is specified through an environment variable:
 
     PAHO_MQTT_C_DIR= ...path to install directory...
-    
+
 It's assumed that the headers are in an _include/_ directory below the one specified, and the library is in _lib/_ under it. This would be the case with a normal install.
 
 Alternately, this can be expressed with individual environment variables for each of the header and library directories:
@@ -182,7 +182,7 @@ In this case, the headers and library can be found independently. This was neces
 
 #### Linking to an installed Paho C library
 
-If the correct version of the Paho C library is expected to be installed on the target system, the simplest solution is to use the pre-generated bindings and specify a link to the shared paho C library. 
+If the correct version of the Paho C library is expected to be installed on the target system, the simplest solution is to use the pre-generated bindings and specify a link to the shared paho C library.
 
     $ cargo build --no-default-features --features "ssl"
 
@@ -244,7 +244,7 @@ export LIBCLANG_PATH=/usr/lib/llvm-3.9/lib
 
 ### Cross-Compiling
 
-I was pleasently surprised to discover that the *cmake* crate automatically handles cross-compiling libraries. You'll need a C cross-compiler installed on your system. See here for more info about cross-compiling Rust, in general: 
+I was pleasently surprised to discover that the *cmake* crate automatically handles cross-compiling libraries. You'll need a C cross-compiler installed on your system. See here for more info about cross-compiling Rust, in general:
 
 https://github.com/japaric/rust-cross
 
@@ -341,4 +341,3 @@ Several external projects are under development which use or enhance the Paho MQ
 The `mqtt-redis` create allows the use of Redis as a persistence store. It also provides a good example of creating a user-defined persistence which implements the `ClientPersistence` trait. It can be found at:
 
 https://github.com/fpagliughi/mqtt.rust.redis
-

--- a/about.html
+++ b/about.html
@@ -5,22 +5,22 @@
 </head>
 <body lang="EN-US">
 <h2>About This Content</h2>
- 
-<p><em>December 9, 2013</em></p>	
+
+<p><em>December 9, 2013</em></p>
 <h3>License</h3>
 
-<p>The Eclipse Foundation makes available all content in this plug-in ("Content").  Unless otherwise 
+<p>The Eclipse Foundation makes available all content in this plug-in ("Content").  Unless otherwise
 indicated below, the Content is provided to you under the terms and conditions of the
 Eclipse Public License Version 1.0 ("EPL") and Eclipse Distribution License Version 1.0 ("EDL").
-A copy of the EPL is available at 
-<a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a> 
-and a copy of the EDL is available at 
-<a href="http://www.eclipse.org/org/documents/edl-v10.php">http://www.eclipse.org/org/documents/edl-v10.php</a>. 
+A copy of the EPL is available at
+<a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>
+and a copy of the EDL is available at
+<a href="http://www.eclipse.org/org/documents/edl-v10.php">http://www.eclipse.org/org/documents/edl-v10.php</a>.
 For purposes of the EPL, "Program" will mean the Content.</p>
 
-<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is
 being redistributed by another party ("Redistributor") and different terms and conditions may
-apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+apply to your use of any object code in the Content.  Check the Redistributor's license that was
 provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
 indicated below, the terms and conditions of the EPL still apply to any source code in the Content
 and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>

--- a/edl-v10
+++ b/edl-v10
@@ -1,4 +1,3 @@
-
 Eclipse Distribution License - v 1.0
 
 Copyright (c) 2007, Eclipse Foundation, Inc. and its licensors.
@@ -9,7 +8,6 @@ Redistribution and use in source and binary forms, with or without modification,
 
     Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
     Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-    Neither the name of the Eclipse Foundation, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission. 
+    Neither the name of the Eclipse Foundation, Inc. nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/examples/async_persist_publish.rs
+++ b/examples/async_persist_publish.rs
@@ -28,18 +28,11 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{
-    env,
-    process,
-    collections::HashMap,
-};
-use log::{
-    trace,
-    debug
-};
+use log::{debug, trace};
 use paho_mqtt as mqtt;
+use std::{collections::HashMap, env, process};
 
-const PERSISTENCE_ERROR: mqtt::Error = mqtt::Error::Paho(-2);    //ffi::MQTTASYNC_PERSISTENCE_ERROR);
+const PERSISTENCE_ERROR: mqtt::Error = mqtt::Error::Paho(-2); //ffi::MQTTASYNC_PERSISTENCE_ERROR);
 
 // Use a non-zero QOS to exercise the persistence store
 const QOS: i32 = 1;
@@ -63,8 +56,7 @@ impl MemPersistence {
     }
 }
 
-impl mqtt::ClientPersistence for MemPersistence
-{
+impl mqtt::ClientPersistence for MemPersistence {
     // Open the persistence store.
     // We don't need to do anything here since the store is in memory.
     // We just capture the name for logging/debugging purposes.
@@ -97,7 +89,7 @@ impl mqtt::ClientPersistence for MemPersistence
         trace!("Client persistence [{}]: get key '{}'", self.name, key);
         match self.map.get(key) {
             Some(v) => Ok(v.to_vec()),
-            None => Err(PERSISTENCE_ERROR)
+            None => Err(PERSISTENCE_ERROR),
         }
     }
 
@@ -106,7 +98,7 @@ impl mqtt::ClientPersistence for MemPersistence
         trace!("Client persistence [{}]: remove key '{}'", self.name, key);
         match self.map.remove(key) {
             Some(_) => Ok(()),
-            None => Err(PERSISTENCE_ERROR)
+            None => Err(PERSISTENCE_ERROR),
         }
     }
 
@@ -141,17 +133,17 @@ fn main() {
     // Initialize the logger from the environment
     env_logger::init();
 
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
     // Create a client & define connect options
     println!("Creating the MQTT client.");
     let create_opts = mqtt::CreateOptionsBuilder::new()
-            .server_uri(host)
-            .user_persistence(MemPersistence::new())
-            .client_id("rust_async_persist_publish")
-            .finalize();
+        .server_uri(host)
+        .user_persistence(MemPersistence::new())
+        .client_id("rust_async_persist_publish")
+        .finalize();
 
     let cli = mqtt::AsyncClient::new(create_opts).unwrap_or_else(|e| {
         println!("Error creating the client: {:?}", e);

--- a/examples/async_publish.rs
+++ b/examples/async_publish.rs
@@ -24,9 +24,9 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{env, process };
 use futures::executor::block_on;
 use paho_mqtt as mqtt;
+use std::{env, process};
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -35,9 +35,9 @@ fn main() {
     env_logger::init();
 
     // Command-line option(s)
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
     // Create a client to the specified host, no persistence
     let create_opts = mqtt::CreateOptionsBuilder::new()

--- a/examples/async_publish_time.rs
+++ b/examples/async_publish_time.rs
@@ -29,16 +29,11 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{
-    env,
-    process,
-    thread,
-    time::{
-        SystemTime,
-        Duration
-    },
-};
 use paho_mqtt as mqtt;
+use std::{
+    env, process, thread,
+    time::{Duration, SystemTime},
+};
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -47,16 +42,17 @@ fn time_now_hundredths() -> u64 {
     (SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
-        .as_millis()/10) as u64
+        .as_millis()
+        / 10) as u64
 }
 
 fn main() {
     // Initialize the logger from the environment
     env_logger::init();
 
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
     // Create a client & define connect options
     let cli = mqtt::AsyncClient::new(host).unwrap_or_else(|err| {

--- a/examples/async_subscribe.rs
+++ b/examples/async_subscribe.rs
@@ -32,19 +32,12 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{
-    env,
-    process,
-    time::Duration
-};
-use futures::{
-    executor::block_on,
-    stream::StreamExt,
-};
+use futures::{executor::block_on, stream::StreamExt};
 use paho_mqtt as mqtt;
+use std::{env, process, time::Duration};
 
 // The topics to which we subscribe.
-const TOPICS: &[&str] = &[ "test", "hello" ];
+const TOPICS: &[&str] = &["test", "hello"];
 const QOS: &[i32] = &[1, 1];
 
 /////////////////////////////////////////////////////////////////////////////
@@ -53,9 +46,9 @@ fn main() {
     // Initialize the logger from the environment
     env_logger::init();
 
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
     // Create the client. Use an ID for a persistent session.
     // A real system should try harder to use a unique ID.
@@ -75,8 +68,7 @@ fn main() {
         let mut strm = cli.get_stream(25);
 
         // Define the set of options for the connection
-        let lwt = mqtt::Message::new("test", "Async subscriber lost connection",
-                                     mqtt::QOS_1);
+        let lwt = mqtt::Message::new("test", "Async subscriber lost connection", mqtt::QOS_1);
 
         let conn_opts = mqtt::ConnectOptionsBuilder::new()
             .keep_alive_interval(Duration::from_secs(20))
@@ -98,8 +90,7 @@ fn main() {
         while let Some(msg_opt) = strm.next().await {
             if let Some(msg) = msg_opt {
                 println!("{}", msg);
-            }
-            else {
+            } else {
                 // A "None" means we were disconnected. Try to reconnect...
                 println!("Lost connection. Attempting reconnect.");
                 while let Err(err) = cli.reconnect().await {

--- a/examples/dyn_subscribe.rs
+++ b/examples/dyn_subscribe.rs
@@ -36,16 +36,10 @@
 
 use paho_mqtt as mqtt;
 
-use std::{
-    env,
-    process,
-    thread,
-    time::Duration,
-    sync::RwLock,
-};
+use std::{env, process, sync::RwLock, thread, time::Duration};
 
 // The topics to which we subscribe.
-const DFLT_TOPICS: &[&str] = &[ "requests/subscription/add", "test", "hello" ];
+const DFLT_TOPICS: &[&str] = &["requests/subscription/add", "test", "hello"];
 const QOS: i32 = 1;
 
 // The type we'll use to keep our dynamic list of topics inside the
@@ -66,7 +60,7 @@ fn on_connect_success(cli: &mqtt::AsyncClient, _msgid: u16) {
         println!("Subscribing to topics: {:?}", topics);
 
         // Create a QoS vector, same len as # topics
-        let qos = vec![QOS ; topics.len()];
+        let qos = vec![QOS; topics.len()];
         // Subscribe to the desired topic(s).
         cli.subscribe_many(&topics, &qos);
         // TODO: This doesn't yet handle a failed subscription.
@@ -92,13 +86,11 @@ fn main() {
     // Initialize the logger from the environment
     env_logger::init();
 
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
-    let topics: Vec<String> = DFLT_TOPICS.iter()
-        .map(|s| s.to_string())
-        .collect();
+    let topics: Vec<String> = DFLT_TOPICS.iter().map(|s| s.to_string()).collect();
 
     // Create the client. Use an ID for a persistent session.
     // A real system should try harder to use a unique ID.
@@ -130,7 +122,7 @@ fn main() {
 
     // Attach a closure to the client to receive callback
     // on incoming messages.
-    cli.set_message_callback(|cli,msg| {
+    cli.set_message_callback(|cli, msg| {
         if let Some(msg) = msg {
             let topic = msg.topic();
             let payload_str = msg.payload_str();
@@ -143,12 +135,10 @@ fn main() {
                     println!("Adding topic: {}", new_topic);
                     cli.subscribe(&new_topic, QOS);
                     topics.push(new_topic);
-                }
-                else {
+                } else {
                     println!("Failed to add topic: {}", payload_str);
                 }
-            }
-            else {
+            } else {
                 println!("{} - {}", topic, payload_str);
             }
         }

--- a/examples/legacy_async_publish.rs
+++ b/examples/legacy_async_publish.rs
@@ -28,8 +28,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{env, process};
 use paho_mqtt as mqtt;
+use std::{env, process};
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -38,9 +38,9 @@ fn main() {
     env_logger::init();
 
     // Command-line option(s)
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
     // Create a client to the specified host, no persistence
     let create_opts = mqtt::CreateOptionsBuilder::new()

--- a/examples/legacy_async_subscribe.rs
+++ b/examples/legacy_async_subscribe.rs
@@ -34,15 +34,10 @@
 
 use paho_mqtt as mqtt;
 
-use std::{
-    env,
-    process,
-    thread,
-    time::Duration
-};
+use std::{env, process, thread, time::Duration};
 
 // The topics to which we subscribe.
-const TOPICS: &[&str] = &[ "test", "hello" ];
+const TOPICS: &[&str] = &["test", "hello"];
 const QOS: &[i32] = &[1, 1];
 
 /////////////////////////////////////////////////////////////////////////////
@@ -76,9 +71,9 @@ fn main() {
     // Initialize the logger from the environment
     env_logger::init();
 
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
     // Create the client. Use an ID for a persistent session.
     // A real system should try harder to use a unique ID.
@@ -109,7 +104,7 @@ fn main() {
 
     // Attach a closure to the client to receive callback
     // on incoming messages.
-    cli.set_message_callback(|_cli,msg| {
+    cli.set_message_callback(|_cli, msg| {
         if let Some(msg) = msg {
             let topic = msg.topic();
             let payload_str = msg.payload_str();

--- a/examples/mqttrs_chat.rs
+++ b/examples/mqttrs_chat.rs
@@ -30,14 +30,10 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-#[macro_use] extern crate paho_mqtt as mqtt;
+#[macro_use]
+extern crate paho_mqtt as mqtt;
 
-use std::{
-    env,
-    process,
-    io,
-    time::Duration,
-};
+use std::{env, io, process, time::Duration};
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -69,7 +65,7 @@ fn main() -> mqtt::Result<()> {
     // The LWT is broadcast to the group if our connection is lost
     // But wait 30sec for reconnect before broadcasting it.
 
-    let lwt_props = mqtt::properties!{
+    let lwt_props = mqtt::properties! {
         mqtt::PropertyCode::WillDelayInterval => 10,
     };
 
@@ -93,7 +89,7 @@ fn main() -> mqtt::Result<()> {
         process::exit(1);
     });
 
-    let props = mqtt::properties!{
+    let props = mqtt::properties! {
         mqtt::PropertyCode::SessionExpiryInterval => 60,
     };
 
@@ -140,17 +136,21 @@ fn main() -> mqtt::Result<()> {
 
     // Let everyone know that a new user joined the group
 
-    topic.publish(format!("<<< {} joined the group >>>", chat_user)).wait()?;
+    topic
+        .publish(format!("<<< {} joined the group >>>", chat_user))
+        .wait()?;
 
-	// Read messages from the console and publish them.
-	// Quit when the use enters an empty line, or a read error occurs.
+    // Read messages from the console and publish them.
+    // Quit when the use enters an empty line, or a read error occurs.
 
     loop {
         let mut input = String::new();
         match io::stdin().read_line(&mut input) {
             Ok(_) => {
                 let msg = input.trim();
-                if msg.is_empty() { break; }
+                if msg.is_empty() {
+                    break;
+                }
 
                 // Publish payload as "<user>: <message>"
                 let chat_msg = format!("{}: {}", chat_user, msg);
@@ -158,7 +158,7 @@ fn main() -> mqtt::Result<()> {
                     eprintln!("Error: {}", err);
                     break;
                 }
-            },
+            }
             Err(err) => println!("Error: {}", err),
         }
     }
@@ -177,4 +177,3 @@ fn main() -> mqtt::Result<()> {
 
     Ok(())
 }
-

--- a/examples/rpc_math_cli.rs
+++ b/examples/rpc_math_cli.rs
@@ -31,13 +31,11 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-#[macro_use] extern crate paho_mqtt as mqtt;
+#[macro_use]
+extern crate paho_mqtt as mqtt;
 
-use std::{
-    env,
-    process,
-};
 use serde_json::json;
+use std::{env, process};
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -69,7 +67,6 @@ fn main() -> mqtt::Result<()> {
         .persistence(mqtt::PersistenceType::None)
         .finalize();
 
-
     let mut cli = mqtt::AsyncClient::new(create_opts).unwrap_or_else(|err| {
         eprintln!("Error creating the client: {}", err);
         process::exit(1);
@@ -97,7 +94,8 @@ fn main() -> mqtt::Result<()> {
     // response. The Client ID will help form a unique "reply to" topic
     // for us.
 
-    let client_id = rsp.properties()
+    let client_id = rsp
+        .properties()
         .get_string(mqtt::PropertyCode::AssignedClientIdentifer)
         .unwrap_or_else(|| {
             eprintln!("Unable to retrieve Client ID");
@@ -112,7 +110,7 @@ fn main() -> mqtt::Result<()> {
 
     let corr_id = b"1";
 
-    let props = mqtt::properties!{
+    let props = mqtt::properties! {
         mqtt::PropertyCode::ResponseTopic => reply_topic,
         mqtt::PropertyCode::CorrelationData => corr_id,
     };
@@ -126,7 +124,8 @@ fn main() -> mqtt::Result<()> {
     // The payload is the JSON array of arguments for the operation.
     // These are the remaining arguments from the command line.
 
-    let math_args: Vec<_> = args[1..].iter()
+    let math_args: Vec<_> = args[1..]
+        .iter()
         .map(|s| s.parse::<f64>())
         .filter_map(Result::ok)
         .collect();
@@ -153,18 +152,18 @@ fn main() -> mqtt::Result<()> {
     // Since we only sent one request, this should certainly be our reply!
 
     if let Some(msg) = rx.recv().unwrap() {
-        let reply_corr_id = msg.properties()
-            .get_binary(mqtt::PropertyCode::CorrelationData).unwrap();
+        let reply_corr_id = msg
+            .properties()
+            .get_binary(mqtt::PropertyCode::CorrelationData)
+            .unwrap();
 
         if reply_corr_id == corr_id {
             let ret: f64 = serde_json::from_str(&msg.payload_str()).unwrap();
             println!("{}", ret);
-        }
-        else {
+        } else {
             eprintln!("Unknown response for {:?}", reply_corr_id);
         }
-    }
-    else {
+    } else {
         eprintln!("Error receiving reply.");
     }
 
@@ -172,4 +171,3 @@ fn main() -> mqtt::Result<()> {
     cli.disconnect(None).wait()?;
     Ok(())
 }
-

--- a/examples/rpc_math_srvr.rs
+++ b/examples/rpc_math_srvr.rs
@@ -31,16 +31,12 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate lazy_static;
 
-use std::{
-    process,
-    thread,
-    collections::HashMap,
-    time::Duration,
-};
-use serde_json::json;
 use paho_mqtt as mqtt;
+use serde_json::json;
+use std::{collections::HashMap, process, thread, time::Duration};
 
 const QOS: i32 = 1;
 const MQTTV5: u32 = 5;
@@ -49,8 +45,12 @@ const MQTTV5: u32 = 5;
 
 // The RPC function implementations
 
-fn add(args: &[f64]) -> f64 { args.iter().sum() }
-fn mult(args: &[f64]) -> f64 { args.iter().product() }
+fn add(args: &[f64]) -> f64 {
+    args.iter().sum()
+}
+fn mult(args: &[f64]) -> f64 {
+    args.iter().product()
+}
 
 // The math function signature.
 type MathFn = fn(args: &[f64]) -> f64;
@@ -68,15 +68,13 @@ lazy_static! {
     };
 }
 
-
 // --------------------------------------------------------------------------
 // This will attempt to reconnect to the broker. It can be called after
 // connection is lost. In this example, we try to reconnect several times,
 // with a few second pause between each attempt. A real system might keep
 // trying indefinitely, with a backoff, or something like that.
 
-fn try_reconnect(cli: &mqtt::AsyncClient) -> bool
-{
+fn try_reconnect(cli: &mqtt::AsyncClient) -> bool {
     println!("Connection lost. Waiting to retry connection");
     for _ in 0..24 {
         thread::sleep(Duration::from_millis(2500));
@@ -104,19 +102,23 @@ fn try_reconnect(cli: &mqtt::AsyncClient) -> bool
 // Correlation ID for the response.
 //
 
-fn handle_request(cli: &mqtt::AsyncClient, msg: mqtt::Message) -> mqtt::Result<()>
-{
+fn handle_request(cli: &mqtt::AsyncClient, msg: mqtt::Message) -> mqtt::Result<()> {
     // We need both a response topic and correlation data to respond.
 
-    let reply_to = msg.properties()
+    let reply_to = msg
+        .properties()
         .get_string(mqtt::PropertyCode::ResponseTopic)
         .ok_or_else(|| mqtt::Error::from("No response topic provided."))?;
 
-    let corr_id = msg.properties()
+    let corr_id = msg
+        .properties()
         .get_binary(mqtt::PropertyCode::CorrelationData)
         .ok_or_else(|| mqtt::Error::from("No correlation data provided."))?;
 
-    println!("\nRequest w/ Reply To: {}, Correlation ID: {:?}", reply_to, corr_id);
+    println!(
+        "\nRequest w/ Reply To: {}, Correlation ID: {:?}",
+        reply_to, corr_id
+    );
 
     // Get the name of the function from the topic
 
@@ -142,7 +144,9 @@ fn handle_request(cli: &mqtt::AsyncClient, msg: mqtt::Message) -> mqtt::Result<(
         // Form a reply message, using the correlation ID
 
         let mut props = mqtt::Properties::new();
-        props.push_binary(mqtt::PropertyCode::CorrelationData, corr_id).unwrap();
+        props
+            .push_binary(mqtt::PropertyCode::CorrelationData, corr_id)
+            .unwrap();
 
         // Create the reply message and publish it on the response topic
 
@@ -156,8 +160,7 @@ fn handle_request(cli: &mqtt::AsyncClient, msg: mqtt::Message) -> mqtt::Result<(
             .finalize();
 
         let _ = cli.publish(msg);
-    }
-    else {
+    } else {
         eprintln!("Unknown command: {}", fname);
     }
     Ok(())
@@ -181,7 +184,6 @@ fn main() -> mqtt::Result<()> {
         .client_id("rpc_math_srvr")
         .persistence(mqtt::PersistenceType::None)
         .finalize();
-
 
     let mut cli = mqtt::AsyncClient::new(create_opts).unwrap_or_else(|err| {
         eprintln!("Error creating the client: {}", err);
@@ -210,7 +212,10 @@ fn main() -> mqtt::Result<()> {
     // the server already knows about us and rembers about out
     // subscription(s). If not, we subscribe for incoming requests.
 
-    if let Some(mqtt::ConnectResponse { session_present, .. }) = rsp.connect_response() {
+    if let Some(mqtt::ConnectResponse {
+        session_present, ..
+    }) = rsp.connect_response()
+    {
         if !session_present {
             println!("Subscribing to math requests");
             cli.subscribe(REQ_TOPIC_HDR, QOS).wait()?;
@@ -223,9 +228,7 @@ fn main() -> mqtt::Result<()> {
             if let Err(err) = handle_request(&cli, msg) {
                 eprintln!("Error: {}", err);
             }
-        }
-        else if cli.is_connected() ||
-                !try_reconnect(&cli) {
+        } else if cli.is_connected() || !try_reconnect(&cli) {
             break;
         }
     }
@@ -236,4 +239,3 @@ fn main() -> mqtt::Result<()> {
     }
     Ok(())
 }
-

--- a/examples/ssl_publish.rs
+++ b/examples/ssl_publish.rs
@@ -40,9 +40,9 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{env, process};
 use futures::executor::block_on;
 use paho_mqtt as mqtt;
+use std::{env, process};
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -75,9 +75,9 @@ fn main() -> mqtt::Result<()> {
     }
 
     // Let the user override the host, but note the "ssl://" protocol.
-    let host = env::args().nth(1).unwrap_or_else(||
-        "ssl://localhost:18884".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "ssl://localhost:18884".to_string());
 
     println!("Connecting to host: '{}'", host);
 
@@ -86,10 +86,10 @@ fn main() -> mqtt::Result<()> {
     if let Err(err) = block_on(async {
         // Create a client & define connect options
         let cli = mqtt::CreateOptionsBuilder::new()
-                        .server_uri(&host)
-                        .client_id("ssl_publish_rs")
-                        .max_buffered_messages(100)
-                        .create_client()?;
+            .server_uri(&host)
+            .client_id("ssl_publish_rs")
+            .max_buffered_messages(100)
+            .create_client()?;
 
         let ssl_opts = mqtt::SslOptionsBuilder::new()
             .trust_store(trust_store)?

--- a/examples/sync_consume.rs
+++ b/examples/sync_consume.rs
@@ -32,13 +32,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{
-    env,
-    process,
-    thread,
-    time::Duration,
-};
 use paho_mqtt as mqtt;
+use std::{env, process, thread, time::Duration};
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -47,8 +42,7 @@ use paho_mqtt as mqtt;
 // with a few second pause between each attempt. A real system might keep
 // trying indefinitely, with a backoff, or something like that.
 
-fn try_reconnect(cli: &mqtt::Client) -> bool
-{
+fn try_reconnect(cli: &mqtt::Client) -> bool {
     println!("Connection lost. Waiting to retry connection");
     for _ in 0..12 {
         thread::sleep(Duration::from_millis(5000));
@@ -67,9 +61,9 @@ fn main() {
     // Initialize the logger from the environment
     env_logger::init();
 
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
     // Create the client. Use an ID for a persistent session.
     // A real system should try harder to use a unique ID.
@@ -98,7 +92,7 @@ fn main() {
         .will_message(lwt)
         .finalize();
 
-    let subscriptions = [ "test", "hello" ];
+    let subscriptions = ["test", "hello"];
     let qos = [1, 1];
 
     // Make the connection to the broker
@@ -106,8 +100,10 @@ fn main() {
     match cli.connect(conn_opts) {
         Ok(rsp) => {
             if let Some(conn_rsp) = rsp.connect_response() {
-                println!("Connected to: '{}' with MQTT version {}",
-                         conn_rsp.server_uri, conn_rsp.mqtt_version);
+                println!(
+                    "Connected to: '{}' with MQTT version {}",
+                    conn_rsp.server_uri, conn_rsp.mqtt_version
+                );
                 if !conn_rsp.session_present {
                     // Register subscriptions on the server
                     println!("Subscribing to topics, with requested QoS: {:?}...", qos);
@@ -122,7 +118,7 @@ fn main() {
                     }
                 }
             }
-        },
+        }
         Err(e) => {
             println!("Error connecting to the broker: {:?}", e);
             process::exit(1);
@@ -136,9 +132,7 @@ fn main() {
     for msg in rx.iter() {
         if let Some(msg) = msg {
             println!("{}", msg);
-        }
-        else if cli.is_connected() ||
-                !try_reconnect(&cli) {
+        } else if cli.is_connected() || !try_reconnect(&cli) {
             break;
         }
     }

--- a/examples/sync_publish.rs
+++ b/examples/sync_publish.rs
@@ -26,12 +26,8 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{
-    env,
-    process,
-    time::Duration,
-};
 use paho_mqtt as mqtt;
+use std::{env, process, time::Duration};
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -40,9 +36,9 @@ fn main() {
     env_logger::init();
 
     // Create a client & define connect options
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
     let mut cli = mqtt::Client::new(host).unwrap_or_else(|e| {
         println!("Error creating the client: {:?}", e);
@@ -64,7 +60,6 @@ fn main() {
         .payload("Hello synchronous world!")
         .qos(1)
         .finalize();
-
 
     if let Err(e) = cli.publish(msg) {
         println!("Error sending message: {:?}", e);

--- a/examples/topic_publish.rs
+++ b/examples/topic_publish.rs
@@ -26,48 +26,48 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{env, process};
 use paho_mqtt as mqtt;
+use std::{env, process};
 
 const QOS: i32 = 1;
 
 /////////////////////////////////////////////////////////////////////////////
 
 fn main() {
-	// Initialize the logger from the environment
-	env_logger::init();
+    // Initialize the logger from the environment
+    env_logger::init();
 
-    let host = env::args().nth(1).unwrap_or_else(||
-        "tcp://localhost:1883".to_string()
-    );
+    let host = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "tcp://localhost:1883".to_string());
 
-	// Create a client & define connect options
-	let cli = mqtt::AsyncClient::new(host).unwrap_or_else(|err| {
-		println!("Error creating the client: {}", err);
-		process::exit(1);
-	});
+    // Create a client & define connect options
+    let cli = mqtt::AsyncClient::new(host).unwrap_or_else(|err| {
+        println!("Error creating the client: {}", err);
+        process::exit(1);
+    });
 
-	let conn_opts = mqtt::ConnectOptions::new();
+    let conn_opts = mqtt::ConnectOptions::new();
 
-	// Connect and wait for it to complete or fail
-	if let Err(e) = cli.connect(conn_opts).wait() {
-		println!("Unable to connect: {:?}", e);
-		process::exit(1);
-	}
+    // Connect and wait for it to complete or fail
+    if let Err(e) = cli.connect(conn_opts).wait() {
+        println!("Unable to connect: {:?}", e);
+        process::exit(1);
+    }
 
-	// Create a topic and publish to it
-	println!("Publishing messages on the 'test' topic");
-	let topic = mqtt::Topic::new(&cli, "test", QOS);
-	for _ in 0..5 {
-		let tok = topic.publish("Hello there");
+    // Create a topic and publish to it
+    println!("Publishing messages on the 'test' topic");
+    let topic = mqtt::Topic::new(&cli, "test", QOS);
+    for _ in 0..5 {
+        let tok = topic.publish("Hello there");
 
-		if let Err(e) = tok.wait() {
-			println!("Error sending message: {:?}", e);
-			break;
-		}
-	}
+        if let Err(e) = tok.wait() {
+            println!("Error sending message: {:?}", e);
+            break;
+        }
+    }
 
-	// Disconnect from the broker
-	let tok = cli.disconnect(None);
-	tok.wait().unwrap();
+    // Disconnect from the broker
+    let tok = cli.disconnect(None);
+    tok.wait().unwrap();
 }

--- a/paho-mqtt-sys/Cargo.toml
+++ b/paho-mqtt-sys/Cargo.toml
@@ -26,5 +26,3 @@ ssl = []
 [build-dependencies]
 bindgen = { version = "0.52", optional = true }
 cmake = { version = "0.1", optional = true }
-
-

--- a/paho-mqtt-sys/build.rs
+++ b/paho-mqtt-sys/build.rs
@@ -67,11 +67,18 @@ fn main() {
 fn link_lib_base() -> &'static str {
     if cfg!(feature = "ssl") {
         println!("debug:link Using SSL library");
-        if cfg!(windows) { "paho-mqtt3as-static" } else { "paho-mqtt3as" }
-    }
-    else {
+        if cfg!(windows) {
+            "paho-mqtt3as-static"
+        } else {
+            "paho-mqtt3as"
+        }
+    } else {
         println!("debug:link Using non-SSL library");
-        if cfg!(windows) { "paho-mqtt3a-static" } else { "paho-mqtt3a" }
+        if cfg!(windows) {
+            "paho-mqtt3a-static"
+        } else {
+            "paho-mqtt3a"
+        }
     }
 }
 
@@ -79,18 +86,18 @@ fn link_lib_base() -> &'static str {
 // directories under the specified install path.
 // On success returns the path and base library name (i.e. the search path
 // and link library name).
-fn find_link_lib<P>(install_path: P) -> Option<(PathBuf,&'static str)>
-    where P: AsRef<Path>
+fn find_link_lib<P>(install_path: P) -> Option<(PathBuf, &'static str)>
+where
+    P: AsRef<Path>,
 {
     let install_path = install_path.as_ref();
-    let lib_dirs = &[ "lib", "lib64" ];
+    let lib_dirs = &["lib", "lib64"];
 
     let lib_base = link_lib_base();
 
     let lib_file = if cfg!(windows) {
         format!("{}.lib", lib_base)
-    }
-    else {
+    } else {
         format!("lib{}.a", lib_base)
     };
 
@@ -112,7 +119,7 @@ fn find_link_lib<P>(install_path: P) -> Option<(PathBuf,&'static str)>
 #[cfg(not(feature = "build_bindgen"))]
 mod bindings {
     use super::*;
-    use std::{fs, env};
+    use std::{env, fs};
 
     pub fn place_bindings(_inc_dir: &Path) {
         let target = env::var("TARGET").unwrap();
@@ -124,19 +131,24 @@ mod bindings {
         let target_ptr_wd = env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap();
         println!("debug:Target Pointer Width: {}", target_ptr_wd);
 
-        let mut bindings = format!("bindings/bindings_paho_mqtt_c_{}-{}.rs",
-                                   PAHO_MQTT_C_VERSION, target);
+        let mut bindings = format!(
+            "bindings/bindings_paho_mqtt_c_{}-{}.rs",
+            PAHO_MQTT_C_VERSION, target
+        );
 
         if !Path::new(&bindings).exists() {
-            println!("No bindings exist for: {}. Using {}-bit default.",
-                     bindings, target_ptr_wd);
-            bindings = format!("bindings/bindings_paho_mqtt_c_{}-default-{}.rs",
-                    PAHO_MQTT_C_VERSION, target_ptr_wd)
+            println!(
+                "No bindings exist for: {}. Using {}-bit default.",
+                bindings, target_ptr_wd
+            );
+            bindings = format!(
+                "bindings/bindings_paho_mqtt_c_{}-default-{}.rs",
+                PAHO_MQTT_C_VERSION, target_ptr_wd
+            )
         }
 
         println!("debug:Using bindings from: {}", bindings);
-        fs::copy(&bindings, out_path)
-            .expect("Could not copy bindings to output directory");
+        fs::copy(&bindings, out_path).expect("Could not copy bindings to output directory");
     }
 }
 
@@ -146,8 +158,8 @@ mod bindings {
     extern crate bindgen;
 
     use super::*;
-    use std::{fs, env};
     use std::path::{Path, PathBuf};
+    use std::{env, fs};
 
     pub fn place_bindings(inc_dir: &Path) {
         println!("debug:Using bindgen for Paho C");
@@ -166,7 +178,8 @@ mod bindings {
             .trust_clang_mangling(false)
             // The input header we would like to generate
             // bindings for.
-            .header("wrapper.h").clang_arg(inc_search)
+            .header("wrapper.h")
+            .clang_arg(inc_search)
             // Finish the builder and generate the bindings.
             .generate()
             // Unwrap the Result and panic on failure.
@@ -176,7 +189,8 @@ mod bindings {
         let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
         let out_path = out_dir.join("bindings.rs");
 
-        bindings.write_to_file(out_path.clone())
+        bindings
+            .write_to_file(out_path.clone())
             .expect("Couldn't write bindings!");
 
         // Save a copy of the bindings file into the bindings/ dir
@@ -185,14 +199,15 @@ mod bindings {
         let target = env::var("TARGET").unwrap();
         println!("debug:Target: {}", target);
 
-        let bindings = format!("bindings/bindings_paho_mqtt_c_{}-{}.rs",
-                               PAHO_MQTT_C_VERSION, target);
+        let bindings = format!(
+            "bindings/bindings_paho_mqtt_c_{}-{}.rs",
+            PAHO_MQTT_C_VERSION, target
+        );
 
         if !Path::new(&bindings).exists() {
             if let Err(err) = fs::copy(out_path, &bindings) {
                 println!("debug:Error copying new binding file: {}", err);
-            }
-            else {
+            } else {
                 println!("debug:Created new bindings file {}", bindings)
             }
         }
@@ -208,10 +223,10 @@ mod build {
     extern crate cmake;
 
     use super::*;
-    use std::process;
-    use std::path::Path;
-    use std::process::Command;
     use std::env;
+    use std::path::Path;
+    use std::process;
+    use std::process::Command;
 
     pub fn main() {
         println!("debug:Running the bundled build for Paho C");
@@ -223,8 +238,8 @@ mod build {
 
         if !Path::new("paho.mqtt.c/.git").exists() {
             let _ = Command::new("git")
-                        .args(&["submodule", "update", "--init"])
-                        .status();
+                .args(&["submodule", "update", "--init"])
+                .status();
         }
 
         // Use and configure cmake to build the Paho C lib
@@ -255,10 +270,14 @@ mod build {
             _ => {
                 println!("Error building Paho C library.");
                 process::exit(103);
-            },
+            }
         };
 
-        println!("debug:Using Paho C library at: {} [{}]", lib_path.display(), link_lib);
+        println!(
+            "debug:Using Paho C library at: {} [{}]",
+            lib_path.display(),
+            link_lib
+        );
 
         // Get bundled bindings or regenerate
         let inc_dir = cmk_install_path.join("include");
@@ -273,16 +292,14 @@ mod build {
                 println!("cargo:rustc-link-lib=libcrypto");
                 if let Ok(ssl_sp) = env::var("OPENSSL_ROOT_DIR") {
                     println!("cargo:rustc-link-search={}\\lib", ssl_sp);
-                }
-                else {
+                } else {
                     #[cfg(target_arch = "x86")]
                     println!("cargo:rustc-link-search={}\\lib", "C:\\OpenSSL-Win32");
 
                     #[cfg(target_arch = "x86_64")]
                     println!("cargo:rustc-link-search={}\\lib", "C:\\OpenSSL-Win64");
                 };
-            }
-            else {
+            } else {
                 println!("cargo:rustc-link-lib=ssl");
                 println!("cargo:rustc-link-lib=crypto");
                 if let Ok(ssl_sp) = env::var("OPENSSL_ROOT_DIR") {
@@ -296,7 +313,6 @@ mod build {
         println!("cargo:rustc-link-lib=static={}", link_lib);
     }
 }
-
 
 // Here we're building with an existing Paho C library.
 // This can be a library installed on the system or the location might be
@@ -331,21 +347,17 @@ mod build {
 
                 println!("cargo:rustc-link-search={}", lib_dir);
                 Some(inc_dir)
-            }
-            else {
+            } else {
                 panic!("If specifying lib dir, must also specify include dir");
             }
-        }
-        else if let Ok(dir) = env::var("PAHO_MQTT_C_DIR") {
+        } else if let Ok(dir) = env::var("PAHO_MQTT_C_DIR") {
             if let Some((lib_path, _link_lib)) = find_link_lib(&dir) {
                 println!("cargo:rustc-link-search={}", lib_path.display());
                 Some(format!("{}/include", dir))
-            }
-            else {
+            } else {
                 None
             }
-        }
-        else {
+        } else {
             None
         }
     }
@@ -365,4 +377,3 @@ mod build {
         bindings::place_bindings(&Path::new(&inc_dir));
     }
 }
-

--- a/paho-mqtt-sys/src/lib.rs
+++ b/paho-mqtt-sys/src/lib.rs
@@ -23,13 +23,12 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-
 // Temporary
 #![allow(dead_code)]
 
-use std::ptr;
 use std::fmt;
 use std::os::raw::{c_char, c_int};
+use std::ptr;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
@@ -45,7 +44,12 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 impl Default for MQTTAsync_createOptions {
     fn default() -> MQTTAsync_createOptions {
         MQTTAsync_createOptions {
-            struct_id: [ b'M' as c_char, b'Q' as c_char, b'C' as c_char, b'O' as c_char],
+            struct_id: [
+                b'M' as c_char,
+                b'Q' as c_char,
+                b'C' as c_char,
+                b'O' as c_char,
+            ],
             struct_version: 1,
             sendWhileDisconnected: 0,
             maxBufferedMessages: 100,
@@ -73,7 +77,12 @@ impl MQTTAsync_createOptions {
 impl Default for MQTTAsync_connectOptions {
     fn default() -> MQTTAsync_connectOptions {
         MQTTAsync_connectOptions {
-            struct_id: [ b'M' as c_char, b'Q' as c_char, b'T' as c_char, b'C' as c_char],
+            struct_id: [
+                b'M' as c_char,
+                b'Q' as c_char,
+                b'T' as c_char,
+                b'C' as c_char,
+            ],
             struct_version: 7,
             keepAliveInterval: 60,
             cleansession: 1,
@@ -113,8 +122,13 @@ impl Default for MQTTAsync_connectOptions {
 impl Default for MQTTAsync_willOptions {
     fn default() -> MQTTAsync_willOptions {
         MQTTAsync_willOptions {
-            struct_id: [ b'M' as c_char, b'Q' as c_char, b'T' as c_char, b'W' as c_char ],
-            struct_version: 1,  // 1 indicates binary payload
+            struct_id: [
+                b'M' as c_char,
+                b'Q' as c_char,
+                b'T' as c_char,
+                b'W' as c_char,
+            ],
+            struct_version: 1, // 1 indicates binary payload
             topicName: ptr::null(),
             message: ptr::null(),
             retained: 0,
@@ -122,7 +136,7 @@ impl Default for MQTTAsync_willOptions {
             payload: MQTTAsync_willOptions__bindgen_ty_1 {
                 len: 0,
                 data: ptr::null(),
-            }
+            },
         }
     }
 }
@@ -130,7 +144,12 @@ impl Default for MQTTAsync_willOptions {
 impl Default for MQTTAsync_SSLOptions {
     fn default() -> MQTTAsync_SSLOptions {
         MQTTAsync_SSLOptions {
-            struct_id: [ b'M' as c_char, b'Q' as c_char, b'T' as c_char, b'S' as c_char ],
+            struct_id: [
+                b'M' as c_char,
+                b'Q' as c_char,
+                b'T' as c_char,
+                b'S' as c_char,
+            ],
             struct_version: 4,
             trustStore: ptr::null(),
             keyStore: ptr::null(),
@@ -154,7 +173,12 @@ impl Default for MQTTAsync_SSLOptions {
 impl Default for MQTTSubscribe_options {
     fn default() -> MQTTSubscribe_options {
         MQTTSubscribe_options {
-            struct_id: [ b'M' as c_char, b'Q' as c_char, b'S' as c_char, b'O' as c_char ],
+            struct_id: [
+                b'M' as c_char,
+                b'Q' as c_char,
+                b'S' as c_char,
+                b'O' as c_char,
+            ],
             struct_version: 0,
             noLocal: 0,
             retainAsPublished: 0,
@@ -163,11 +187,15 @@ impl Default for MQTTSubscribe_options {
     }
 }
 
-
 impl Default for MQTTAsync_responseOptions {
     fn default() -> MQTTAsync_responseOptions {
         MQTTAsync_responseOptions {
-            struct_id: [ b'M' as c_char, b'Q' as c_char, b'T' as c_char, b'R' as c_char ],
+            struct_id: [
+                b'M' as c_char,
+                b'Q' as c_char,
+                b'T' as c_char,
+                b'R' as c_char,
+            ],
             struct_version: 1,
             onSuccess: None,
             onFailure: None,
@@ -204,10 +232,12 @@ impl Default for MQTTProperties {
     }
 }
 
-
 impl Default for MQTTLenString {
     fn default() -> MQTTLenString {
-        MQTTLenString { len: 0, data: ptr::null_mut(), }
+        MQTTLenString {
+            len: 0,
+            data: ptr::null_mut(),
+        }
     }
 }
 
@@ -217,7 +247,12 @@ impl Default for MQTTLenString {
 impl Default for MQTTAsync_message {
     fn default() -> MQTTAsync_message {
         MQTTAsync_message {
-            struct_id: [ b'M' as c_char, b'Q' as c_char, b'T' as c_char, b'M' as c_char ],
+            struct_id: [
+                b'M' as c_char,
+                b'Q' as c_char,
+                b'T' as c_char,
+                b'M' as c_char,
+            ],
             struct_version: 1,
             payloadlen: 0,
             payload: ptr::null_mut(),
@@ -236,7 +271,12 @@ impl Default for MQTTAsync_message {
 impl Default for MQTTAsync_disconnectOptions {
     fn default() -> MQTTAsync_disconnectOptions {
         MQTTAsync_disconnectOptions {
-            struct_id: [ b'M' as c_char, b'Q' as c_char, b'T' as c_char, b'D' as c_char],
+            struct_id: [
+                b'M' as c_char,
+                b'Q' as c_char,
+                b'T' as c_char,
+                b'D' as c_char,
+            ],
             struct_version: 1,
             timeout: 0,
             onSuccess: None,
@@ -280,7 +320,10 @@ impl MQTTAsync_nameValue {
 
 impl Default for MQTTAsync_nameValue {
     fn default() -> Self {
-        Self { name: ptr::null(), value: ptr::null() }
+        Self {
+            name: ptr::null(),
+            value: ptr::null(),
+        }
     }
 }
 
@@ -288,6 +331,4 @@ impl Default for MQTTAsync_nameValue {
 // Unit Tests
 
 #[cfg(test)]
-mod tests {
-}
-
+mod tests {}

--- a/paho-mqtt-sys/wrapper.h
+++ b/paho-mqtt-sys/wrapper.h
@@ -1,2 +1,1 @@
 #include <MQTTAsync.h>
-

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,19 +27,12 @@
 //!
 //! The synchronous calls use a default timeout
 
-use std::{
-    time::Duration,
-    sync::mpsc,
-};
+use std::{sync::mpsc, time::Duration};
 
 use crate::{
-    async_client::AsyncClient,
-    create_options::CreateOptions,
-    connect_options::ConnectOptions,
-    disconnect_options::DisconnectOptions,
+    async_client::AsyncClient, connect_options::ConnectOptions, create_options::CreateOptions,
+    disconnect_options::DisconnectOptions, errors::Result, message::Message,
     server_response::ServerResponse,
-    message::Message,
-    errors::Result,
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -58,13 +51,14 @@ pub struct Client {
 impl Client {
     /// Creates a new MQTT client which can connect to an MQTT broker.
     pub fn new<T>(opts: T) -> Result<Client>
-        where T: Into<CreateOptions>
+    where
+        T: Into<CreateOptions>,
     {
         let async_cli = AsyncClient::new(opts)?;
 
         let cli = Client {
             cli: async_cli,
-            timeout: Duration::from_secs(5*60),
+            timeout: Duration::from_secs(5 * 60),
         };
         //cli.start_consuming();
         Ok(cli)
@@ -87,8 +81,9 @@ impl Client {
     }
 
     /// Connects to an MQTT broker using the specified connect options.
-    pub fn connect<T>(&self, opt_opts:T) -> Result<ServerResponse>
-        where T: Into<Option<ConnectOptions>>
+    pub fn connect<T>(&self, opt_opts: T) -> Result<ServerResponse>
+    where
+        T: Into<Option<ConnectOptions>>,
     {
         self.cli.connect(opt_opts).wait_for(self.timeout)
     }
@@ -100,8 +95,9 @@ impl Client {
     /// `opt_opts` Optional disconnect options. Specifying `None` will use
     ///            default of immediate (zero timeout) disconnect.
     ///
-    pub fn disconnect<T>(&self, opt_opts:T) -> Result<()>
-        where T: Into<Option<DisconnectOptions>>
+    pub fn disconnect<T>(&self, opt_opts: T) -> Result<()>
+    where
+        T: Into<Option<DisconnectOptions>>,
     {
         self.cli.disconnect(opt_opts).wait_for(self.timeout)?;
         Ok(())
@@ -159,7 +155,8 @@ impl Client {
     /// `qos` The quality of service requested for messages
     ///
     pub fn subscribe_many<T>(&self, topics: &[T], qos: &[i32]) -> Result<ServerResponse>
-        where T: AsRef<str>
+    where
+        T: AsRef<str>,
     {
         self.cli.subscribe_many(topics, qos).wait_for(self.timeout)
     }
@@ -184,7 +181,8 @@ impl Client {
     ///         previous subscribe.
     ///
     pub fn unsubscribe_many<T>(&self, topics: &[T]) -> Result<()>
-        where T: AsRef<str>
+    where
+        T: AsRef<str>,
     {
         self.cli.unsubscribe_many(topics).wait_for(self.timeout)?;
         Ok(())
@@ -210,8 +208,8 @@ impl Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::thread;
     use std::sync::Arc;
+    use std::thread;
 
     // Determine that a client can be sent across threads and signaled.
     // As long as it compiles, this indicates that Client implements the
@@ -244,4 +242,3 @@ mod tests {
         let _ = thr.join().unwrap();
     }
 }
-

--- a/src/connect_options.rs
+++ b/src/connect_options.rs
@@ -24,30 +24,19 @@
 //! This contains the structures to define the options for connecting to the
 //! MQTT broker/server.
 
-use std::{
-    ptr,
-    time::Duration,
-    ffi::CString,
-    os::raw::c_int,
-    pin::Pin,
-};
+use std::{ffi::CString, os::raw::c_int, pin::Pin, ptr, time::Duration};
 
 use crate::{
-    ffi,
-    to_c_bool,
-    from_c_bool,
-    token::{
-        ConnectToken,
-        Token,
-        TokenInner,
-    },
+    ffi, from_c_bool,
     message::Message,
-    will_options::WillOptions,
-    ssl_options::SslOptions,
-    string_collection::StringCollection,
     name_value::NameValueCollection,
     properties::Properties,
+    ssl_options::SslOptions,
+    string_collection::StringCollection,
+    to_c_bool,
+    token::{ConnectToken, Token, TokenInner},
     types::*,
+    will_options::WillOptions,
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -87,15 +76,12 @@ impl ConnectOptions {
 
     // Fixes up the underlying C struct to point to our cached values.
     // This should be called any time a cached object is modified.
-    fn from_data(
-        mut copts: ffi::MQTTAsync_connectOptions,
-        data: ConnectOptionsData
-    ) -> Self {
+    fn from_data(mut copts: ffi::MQTTAsync_connectOptions, data: ConnectOptionsData) -> Self {
         let mut data = Box::pin(data);
 
         copts.will = match data.will {
             Some(ref mut will_opts) => &mut will_opts.copts,
-            _ => ptr::null_mut()
+            _ => ptr::null_mut(),
         };
 
         copts.ssl = match data.ssl {
@@ -110,7 +96,7 @@ impl ConnectOptions {
 
         copts.password = match data.password {
             Some(ref password) => password.as_ptr(),
-            _ => ptr::null()
+            _ => ptr::null(),
         };
 
         let n = data.server_uris.len();
@@ -118,8 +104,7 @@ impl ConnectOptions {
         if n != 0 {
             copts.serverURIs = data.server_uris.as_c_arr_mut_ptr();
             copts.serverURIcount = n as c_int;
-        }
-        else {
+        } else {
             copts.serverURIs = ptr::null();
             copts.serverURIcount = 0;
         }
@@ -145,7 +130,7 @@ impl ConnectOptions {
 
         copts.httpHeaders = match data.http_headers {
             Some(ref mut http_headers) => http_headers.as_c_arr_ptr(),
-            _ => ptr::null()
+            _ => ptr::null(),
         };
 
         Self { copts, data }
@@ -175,8 +160,7 @@ impl ConnectOptions {
         if self.copts.MQTTVersion < ffi::MQTTVERSION_5 as i32 {
             self.copts.onSuccess = Some(TokenInner::on_success);
             self.copts.onFailure = Some(TokenInner::on_failure);
-        }
-        else {
+        } else {
             self.copts.onSuccess5 = Some(TokenInner::on_success5);
             self.copts.onFailure5 = Some(TokenInner::on_failure5);
         }
@@ -188,23 +172,19 @@ impl Default for ConnectOptions {
     fn default() -> Self {
         Self::from_data(
             ffi::MQTTAsync_connectOptions::default(),
-            ConnectOptionsData::default()
+            ConnectOptionsData::default(),
         )
     }
 }
 
 impl Clone for ConnectOptions {
     fn clone(&self) -> Self {
-        Self::from_data(
-            self.copts.clone(),
-            (&*self.data).clone()
-        )
+        Self::from_data(self.copts.clone(), (&*self.data).clone())
     }
 }
 
 unsafe impl Send for ConnectOptions {}
 unsafe impl Sync for ConnectOptions {}
-
 
 /////////////////////////////////////////////////////////////////////////////
 //                              Builder
@@ -279,7 +259,7 @@ impl ConnectOptionsBuilder {
     /// # Arguments
     ///
     /// `will` The LWT options for the connection.
-    #[deprecated(note="Pass in a message with `will_message` instead")]
+    #[deprecated(note = "Pass in a message with `will_message` instead")]
     pub fn will_options(&mut self, will: WillOptions) -> &mut Self {
         self.data.will = Some(will);
         self
@@ -314,7 +294,8 @@ impl ConnectOptionsBuilder {
     /// `user_name` The user name to send to the broker.
     ///
     pub fn user_name<S>(&mut self, user_name: S) -> &mut Self
-        where S: Into<String>
+    where
+        S: Into<String>,
     {
         let user_name = CString::new(user_name.into()).unwrap();
         self.data.user_name = Some(user_name);
@@ -329,7 +310,8 @@ impl ConnectOptionsBuilder {
     /// `password` The password to send to the broker.
     ///
     pub fn password<S>(&mut self, password: S) -> &mut Self
-        where S: Into<String>
+    where
+        S: Into<String>,
     {
         let password = CString::new(password.into()).unwrap();
         self.data.password = Some(password);
@@ -368,7 +350,8 @@ impl ConnectOptionsBuilder {
     ///               should connect.
     //
     pub fn server_uris<T>(&mut self, server_uris: &[T]) -> &mut Self
-        where T: AsRef<str>
+    where
+        T: AsRef<str>,
     {
         self.data.server_uris = StringCollection::new(server_uris);
         self
@@ -389,8 +372,7 @@ impl ConnectOptionsBuilder {
 
         if ver < ffi::MQTTVERSION_5 {
             self.copts.cleanstart = 0;
-        }
-        else {
+        } else {
             self.copts.cleansession = 0;
         }
         self
@@ -405,11 +387,12 @@ impl ConnectOptionsBuilder {
     /// `max_retry_interval` The maximum retry interval. Doubling stops here
     ///                      on failed retries. This has a resolution in
     ///                      seconds.
-    pub fn automatic_reconnect(&mut self, min_retry_interval: Duration,
-                                          max_retry_interval: Duration)
-                -> &mut Self
-    {
-        self.copts.automaticReconnect = 1;  // true
+    pub fn automatic_reconnect(
+        &mut self,
+        min_retry_interval: Duration,
+        max_retry_interval: Duration,
+    ) -> &mut Self {
+        self.copts.automaticReconnect = 1; // true
 
         let mut secs = min_retry_interval.as_secs();
         self.copts.minRetryInterval = if secs == 0 { 1 } else { secs as i32 };
@@ -431,9 +414,10 @@ impl ConnectOptionsBuilder {
 
     /// Sets the additional HTTP headers that will be sent in the
     /// WebSocket opening handshake.
-    pub fn http_headers<N,V>(&mut self, coll: &[(N,V)]) -> &mut Self
-        where N: AsRef<str>,
-              V: AsRef<str>,
+    pub fn http_headers<N, V>(&mut self, coll: &[(N, V)]) -> &mut Self
+    where
+        N: AsRef<str>,
+        V: AsRef<str>,
     {
         let coll = NameValueCollection::new(coll);
         self.data.http_headers = Some(coll);
@@ -442,10 +426,7 @@ impl ConnectOptionsBuilder {
 
     /// Finalize the builder to create the connect options.
     pub fn finalize(&self) -> ConnectOptions {
-        ConnectOptions::from_data(
-            self.copts.clone(),
-            self.data.clone()
-        )
+        ConnectOptions::from_data(self.copts.clone(), self.data.clone())
     }
 }
 
@@ -455,21 +436,17 @@ impl ConnectOptionsBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        thread,
-        ffi::CStr,
-        os::raw::c_char,
-    };
-    use crate::{
-        ssl_options::SslOptionsBuilder,
-        message::MessageBuilder,
-        types::*,
-        properties::*,
-    };
     use super::*;
+    use crate::{message::MessageBuilder, properties::*, ssl_options::SslOptionsBuilder, types::*};
+    use std::{ffi::CStr, os::raw::c_char, thread};
 
     // Identifier fo a C connect options struct
-    const STRUCT_ID: [c_char; 4] = [ b'M' as c_char, b'Q' as c_char, b'T' as c_char, b'C' as c_char ];
+    const STRUCT_ID: [c_char; 4] = [
+        b'M' as c_char,
+        b'Q' as c_char,
+        b'T' as c_char,
+        b'C' as c_char,
+    ];
 
     #[test]
     fn test_new() {
@@ -502,7 +479,8 @@ mod tests {
     fn test_ssl() {
         const TRUST_STORE: &str = "some_file.crt";
         let ssl_opts = SslOptionsBuilder::new()
-            .trust_store(TRUST_STORE).unwrap()
+            .trust_store(TRUST_STORE)
+            .unwrap()
             .finalize();
 
         let opts = ConnectOptionsBuilder::new()
@@ -517,8 +495,7 @@ mod tests {
             assert_eq!(&ssl_opts.copts as *const _, opts.copts.ssl);
             let ts = unsafe { CStr::from_ptr((*opts.copts.ssl).trustStore) };
             assert_eq!(TRUST_STORE, ts.to_str().unwrap());
-        }
-        else {
+        } else {
             // The SSL option should be set
             assert!(false);
         };
@@ -528,8 +505,7 @@ mod tests {
     fn test_user_name() {
         const NAME: &str = "some-random-name";
 
-        let opts = ConnectOptionsBuilder::new()
-                        .user_name(NAME).finalize();
+        let opts = ConnectOptionsBuilder::new().user_name(NAME).finalize();
 
         assert!(!opts.copts.username.is_null());
 
@@ -538,8 +514,7 @@ mod tests {
 
             let s = unsafe { CStr::from_ptr(opts.copts.username) };
             assert_eq!(NAME, s.to_str().unwrap());
-        }
-        else {
+        } else {
             assert!(false);
         };
     }
@@ -548,8 +523,7 @@ mod tests {
     fn test_password() {
         const PSWD: &str = "some-random-password";
 
-        let opts = ConnectOptionsBuilder::new()
-                        .password(PSWD).finalize();
+        let opts = ConnectOptionsBuilder::new().password(PSWD).finalize();
 
         assert!(!opts.copts.password.is_null());
 
@@ -558,18 +532,18 @@ mod tests {
 
             let s = unsafe { CStr::from_ptr(opts.copts.password) };
             assert_eq!(PSWD, s.to_str().unwrap());
-        }
-        else {
+        } else {
             assert!(false);
         };
     }
 
     #[test]
     fn test_server_uris() {
-        let servers = [ "tcp://server1:1883", "ssl://server2:1885" ];
+        let servers = ["tcp://server1:1883", "ssl://server2:1885"];
 
         let opts = ConnectOptionsBuilder::new()
-                        .server_uris(&servers).finalize();
+            .server_uris(&servers)
+            .finalize();
 
         assert_eq!(servers.len() as i32, opts.copts.serverURIcount);
 
@@ -596,14 +570,13 @@ mod tests {
         const PASSWORD: &str = "some-password";
         const CONNECT_TIMEOUT_SECS: u64 = 120;
 
-
         let org_opts = ConnectOptionsBuilder::new()
-            .keep_alive_interval(Duration::new(KEEP_ALIVE_SECS,0))
+            .keep_alive_interval(Duration::new(KEEP_ALIVE_SECS, 0))
             .clean_session(false)
             .max_inflight(MAX_INFLIGHT)
             .user_name(USER_NAME)
             .password(PASSWORD)
-            .connect_timeout(Duration::new(CONNECT_TIMEOUT_SECS,0))
+            .connect_timeout(Duration::new(CONNECT_TIMEOUT_SECS, 0))
             .finalize();
 
         let opts = org_opts;
@@ -612,19 +585,23 @@ mod tests {
         assert_eq!(0, opts.copts.cleansession);
         assert_eq!(MAX_INFLIGHT, opts.copts.maxInflight);
 
-        assert_eq!(USER_NAME, opts.data.user_name.as_ref().unwrap().to_str().unwrap());
-        assert_eq!(PASSWORD, opts.data.password.as_ref().unwrap().to_str().unwrap());
+        assert_eq!(
+            USER_NAME,
+            opts.data.user_name.as_ref().unwrap().to_str().unwrap()
+        );
+        assert_eq!(
+            PASSWORD,
+            opts.data.password.as_ref().unwrap().to_str().unwrap()
+        );
 
         if let Some(ref user_name) = opts.data.user_name {
             assert_eq!(user_name.as_ptr(), opts.copts.username)
-        }
-        else {
+        } else {
             assert!(false)
         };
         if let Some(ref password) = opts.data.password {
             assert_eq!(password.as_ptr(), opts.copts.password)
-        }
-        else {
+        } else {
             assert!(false)
         };
 
@@ -634,12 +611,14 @@ mod tests {
     #[test]
     fn test_connect_properties() {
         let mut props = Properties::new();
-        props.push_int(PropertyCode::SessionExpiryInterval, 60).unwrap();
+        props
+            .push_int(PropertyCode::SessionExpiryInterval, 60)
+            .unwrap();
 
         // Remember, you can only set properties on a v5 connection.
         let opts = ConnectOptionsBuilder::new()
-            .properties(props)      // Note: Order shouldn't matter when
-            .mqtt_version(MQTT_VERSION_5)   // building options
+            .properties(props) // Note: Order shouldn't matter when
+            .mqtt_version(MQTT_VERSION_5) // building options
             .finalize();
 
         if let Some(ref props) = opts.data.props {
@@ -647,10 +626,11 @@ mod tests {
             assert_eq!(Some(60), props.get_int(PropertyCode::SessionExpiryInterval));
 
             assert!(!opts.copts.connectProperties.is_null());
-            assert_eq!(&props.cprops as *const _ as *mut ffi::MQTTProperties,
-                       opts.copts.connectProperties);
-        }
-        else {
+            assert_eq!(
+                &props.cprops as *const _ as *mut ffi::MQTTProperties,
+                opts.copts.connectProperties
+            );
+        } else {
             assert!(false)
         };
     }
@@ -673,37 +653,40 @@ mod tests {
 
         if let Some(ref will_props) = opts.data.will_props {
             assert_eq!(1, will_props.len());
-            assert_eq!(Some(60), will_props.get_int(PropertyCode::WillDelayInterval));
+            assert_eq!(
+                Some(60),
+                will_props.get_int(PropertyCode::WillDelayInterval)
+            );
 
             assert!(!opts.copts.willProperties.is_null());
-            assert_eq!(&will_props.cprops as *const _ as *mut ffi::MQTTProperties,
-                       opts.copts.willProperties);
-        }
-        else {
+            assert_eq!(
+                &will_props.cprops as *const _ as *mut ffi::MQTTProperties,
+                opts.copts.willProperties
+            );
+        } else {
             assert!(false)
         };
     }
 
+    /*
+        #[test]
+        fn test_clone() {
+            const TRUST_STORE: &str = "some_file.crt";
+            // Make sure the original goes out of scope
+            // before testing the clone.
+            let opts = {
+                let org_opts = SslOptionsBuilder::new()
+                    .trust_store(TRUST_STORE)
+                    .finalize();
 
-/*
-    #[test]
-    fn test_clone() {
-        const TRUST_STORE: &str = "some_file.crt";
-        // Make sure the original goes out of scope
-        // before testing the clone.
-        let opts = {
-            let org_opts = SslOptionsBuilder::new()
-                .trust_store(TRUST_STORE)
-                .finalize();
+                org_opts.clone()
+            };
 
-            org_opts.clone()
-        };
-
-        assert_eq!(TRUST_STORE, opts.trust_store.to_str().unwrap());
-        let ts = unsafe { CStr::from_ptr(opts.copts.trustStore) };
-        assert_eq!(TRUST_STORE, ts.to_str().unwrap());
-    }
-*/
+            assert_eq!(TRUST_STORE, opts.trust_store.to_str().unwrap());
+            let ts = unsafe { CStr::from_ptr(opts.copts.trustStore) };
+            assert_eq!(TRUST_STORE, ts.to_str().unwrap());
+        }
+    */
 
     // Determine that the options can be sent across threads.
     // As long as it compiles, this indicates that ConnectOptions implements
@@ -719,4 +702,3 @@ mod tests {
         let _ = thr.join().unwrap();
     }
 }
-

--- a/src/create_options.rs
+++ b/src/create_options.rs
@@ -20,17 +20,10 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{
-    fmt,
-    os::raw::c_int,
-};
+use std::{fmt, os::raw::c_int};
 
 use crate::{
-    ffi,
-    Result,
-    UserData,
-    client_persistence::ClientPersistence,
-    async_client::AsyncClient,
+    async_client::AsyncClient, client_persistence::ClientPersistence, ffi, Result, UserData,
 };
 
 /*
@@ -42,22 +35,22 @@ Remember the C constants (c_uint)
 
 /// The type of persistence for the client
 pub enum PersistenceType {
-	/// Data and messages are persisted to a local file (default)
-	File,
-	/// No persistence is used.
-	None,
-	/// A user-defined persistence provided by the application.
-	User(Box<Box<dyn ClientPersistence>>),
+    /// Data and messages are persisted to a local file (default)
+    File,
+    /// No persistence is used.
+    None,
+    /// A user-defined persistence provided by the application.
+    User(Box<Box<dyn ClientPersistence>>),
 }
 
 impl fmt::Debug for PersistenceType {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		match *self {
-			PersistenceType::File => write!(f, "File"),
-			PersistenceType::None => write!(f, "None"),
-			PersistenceType::User(_) => write!(f, "User"),
-		}
-	}
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            PersistenceType::File => write!(f, "File"),
+            PersistenceType::None => write!(f, "None"),
+            PersistenceType::User(_) => write!(f, "User"),
+        }
+    }
 }
 
 impl Default for PersistenceType {
@@ -75,70 +68,70 @@ impl Default for PersistenceType {
 /// [CreateOptionsBuilder](struct.CreateOptionsBuilder.html).
 #[derive(Debug, Default)]
 pub struct CreateOptions {
-	/// The underlying C option structure
-	pub(crate) copts: ffi::MQTTAsync_createOptions,
-	/// The URI for the MQTT broker.
-	pub(crate) server_uri: String,
-	/// The unique name for the client.
-	/// This can be left empty for the server to assign a random name.
-	pub(crate) client_id: String,
-	/// The type of persistence used by the client.
-	pub(crate) persistence: PersistenceType,
+    /// The underlying C option structure
+    pub(crate) copts: ffi::MQTTAsync_createOptions,
+    /// The URI for the MQTT broker.
+    pub(crate) server_uri: String,
+    /// The unique name for the client.
+    /// This can be left empty for the server to assign a random name.
+    pub(crate) client_id: String,
+    /// The type of persistence used by the client.
+    pub(crate) persistence: PersistenceType,
     /// User-defined data, if any
     pub(crate) user_data: Option<UserData>,
 }
 
 impl CreateOptions {
-	pub fn new() -> CreateOptions {
-		CreateOptions::default()
-	}
+    pub fn new() -> CreateOptions {
+        CreateOptions::default()
+    }
 }
 
 impl<'a> From<&'a str> for CreateOptions {
-	fn from(server_uri: &'a str) -> Self {
-		let mut opts = CreateOptions::default();
-		opts.server_uri = server_uri.to_string();
-		opts
-	}
+    fn from(server_uri: &'a str) -> Self {
+        let mut opts = CreateOptions::default();
+        opts.server_uri = server_uri.to_string();
+        opts
+    }
 }
 
 impl From<String> for CreateOptions {
-	fn from(server_uri: String) -> Self {
-		let mut opts = CreateOptions::default();
-		opts.server_uri = server_uri;
-		opts
-	}
+    fn from(server_uri: String) -> Self {
+        let mut opts = CreateOptions::default();
+        opts.server_uri = server_uri;
+        opts
+    }
 }
 
 impl<'a, 'b> From<(&'a str, &'b str)> for CreateOptions {
-	fn from((server_uri, client_id): (&'a str, &'b str)) -> Self {
-		let mut opts = CreateOptions::default();
-		opts.server_uri = server_uri.to_string();
-		opts.client_id = client_id.to_string();
-		opts
-	}
+    fn from((server_uri, client_id): (&'a str, &'b str)) -> Self {
+        let mut opts = CreateOptions::default();
+        opts.server_uri = server_uri.to_string();
+        opts.client_id = client_id.to_string();
+        opts
+    }
 }
 
 impl From<(String, String)> for CreateOptions {
-	fn from((server_uri, client_id): (String, String)) -> Self {
-		let mut opts = CreateOptions::default();
-		opts.server_uri = server_uri;
-		opts.client_id = client_id;
-		opts
-	}
+    fn from((server_uri, client_id): (String, String)) -> Self {
+        let mut opts = CreateOptions::default();
+        opts.server_uri = server_uri;
+        opts.client_id = client_id;
+        opts
+    }
 }
 
 /*
 impl Default for CreateOptions {
-	/// Constructs a set of CreatieOptions with reasonable defaults.
-	fn default() -> CreateOptions {
-		CreateOptions {
-			copts: ffi::MQTTAsync_createOptions::default(),
-			server_uri: "".to_string(),
-			client_id: "".to_string(),
-			persistence: PersistenceType::File,
-		}
-	}
+    /// Constructs a set of CreatieOptions with reasonable defaults.
+    fn default() -> CreateOptions {
+        CreateOptions {
+            copts: ffi::MQTTAsync_createOptions::default(),
+            server_uri: "".to_string(),
+            client_id: "".to_string(),
+            persistence: PersistenceType::File,
+        }
+    }
 }
 */
 
@@ -163,102 +156,109 @@ impl Default for CreateOptions {
 
 #[derive(Default)]
 pub struct CreateOptionsBuilder {
-	copts: ffi::MQTTAsync_createOptions,
-	server_uri: String,
-	client_id: String,
-	persistence: PersistenceType,
-    user_data: Option<UserData>
+    copts: ffi::MQTTAsync_createOptions,
+    server_uri: String,
+    client_id: String,
+    persistence: PersistenceType,
+    user_data: Option<UserData>,
 }
 
 impl CreateOptionsBuilder {
-	/// Constructs a builder with default options.
-	pub fn new() -> Self { Self::default() }
+    /// Constructs a builder with default options.
+    pub fn new() -> Self {
+        Self::default()
+    }
 
-	/// Sets the the URI to the MQTT broker.
-	/// Alternately, the application can specify multiple servers via the
-	/// connect options.
-	///
-	/// # Arguments
-	///
-	/// `server_uri` The URI string to specify the server in the form
-	///              _protocol://host:port_, where the protocol can be
-	///              _tcp_ or _ssl_, and the host can be an IP address
-	///              or domain name.
-	pub fn server_uri<S>(mut self, server_uri: S) -> Self
-			where S: Into<String> {
-		self.server_uri = server_uri.into();
-		self
-	}
+    /// Sets the the URI to the MQTT broker.
+    /// Alternately, the application can specify multiple servers via the
+    /// connect options.
+    ///
+    /// # Arguments
+    ///
+    /// `server_uri` The URI string to specify the server in the form
+    ///              _protocol://host:port_, where the protocol can be
+    ///              _tcp_ or _ssl_, and the host can be an IP address
+    ///              or domain name.
+    pub fn server_uri<S>(mut self, server_uri: S) -> Self
+    where
+        S: Into<String>,
+    {
+        self.server_uri = server_uri.into();
+        self
+    }
 
-	/// Sets the client identifier string that is sent to the server.
-	/// The client ID is a unique name to identify the client to the server,
-	/// which can be used if the client desires the server to hold state
-	/// about the session. If the client requests a clean sesstion, this can
-	/// be an empty string.
-	///
-	/// The broker is required to honor a client ID of up to 23 bytes, but
-	/// could honor longer ones, depending on the broker.
-	///
-	/// Note that if this is an empty string, the clean session parameter
-	/// *must* be set to _true_.
-	///
-	/// # Arguments
-	///
-	/// `client_id` A UTF-8 string identifying the client to the server.
-	///
-	pub fn client_id<S>(mut self, client_id: S) -> Self
-			where S: Into<String> {
-		self.client_id = client_id.into();
-		self
-	}
+    /// Sets the client identifier string that is sent to the server.
+    /// The client ID is a unique name to identify the client to the server,
+    /// which can be used if the client desires the server to hold state
+    /// about the session. If the client requests a clean sesstion, this can
+    /// be an empty string.
+    ///
+    /// The broker is required to honor a client ID of up to 23 bytes, but
+    /// could honor longer ones, depending on the broker.
+    ///
+    /// Note that if this is an empty string, the clean session parameter
+    /// *must* be set to _true_.
+    ///
+    /// # Arguments
+    ///
+    /// `client_id` A UTF-8 string identifying the client to the server.
+    ///
+    pub fn client_id<S>(mut self, client_id: S) -> Self
+    where
+        S: Into<String>,
+    {
+        self.client_id = client_id.into();
+        self
+    }
 
-	/// Sets the type of persistence used by the client.
-	/// The default is for the library to automatically use file persistence,
-	/// although this can be turned off by specify `None` for a more
-	/// performant, though possibly less reliable system.
-	///
-	/// # Arguments
-	///
-	/// `persist` The type of persistence to use.
-	///
-	pub fn persistence(mut self, persist: PersistenceType) -> Self {
-		self.persistence = persist;
-		self
-	}
+    /// Sets the type of persistence used by the client.
+    /// The default is for the library to automatically use file persistence,
+    /// although this can be turned off by specify `None` for a more
+    /// performant, though possibly less reliable system.
+    ///
+    /// # Arguments
+    ///
+    /// `persist` The type of persistence to use.
+    ///
+    pub fn persistence(mut self, persist: PersistenceType) -> Self {
+        self.persistence = persist;
+        self
+    }
 
-	/// Sets a user-defined persistence store.
-	/// This sets the persistence to use a custom one defined by the
-	/// application. This can be anything that implements the
-	/// `ClientPersistence` trait.
-	///
-	/// # Arguments
-	///
-	/// `persist` An application-defined custom persistence store.
-	///
-	pub fn user_persistence<T>(mut self, persistence: T) -> Self
-			where T: ClientPersistence + 'static
-	{
-		let persistence: Box<Box<dyn ClientPersistence>> = Box::new(Box::new(persistence));
-		self.persistence = PersistenceType::User(persistence);
-		self
-	}
+    /// Sets a user-defined persistence store.
+    /// This sets the persistence to use a custom one defined by the
+    /// application. This can be anything that implements the
+    /// `ClientPersistence` trait.
+    ///
+    /// # Arguments
+    ///
+    /// `persist` An application-defined custom persistence store.
+    ///
+    pub fn user_persistence<T>(mut self, persistence: T) -> Self
+    where
+        T: ClientPersistence + 'static,
+    {
+        let persistence: Box<Box<dyn ClientPersistence>> = Box::new(Box::new(persistence));
+        self.persistence = PersistenceType::User(persistence);
+        self
+    }
 
-	/// Sets the maximum number of messages that can be buffered for delivery
-	/// when the client is off-line.
-	/// The client has limited support for bufferering messages when the
-	/// client is temporarily disconnected. This specifies the maximum number
-	/// of messages that can be buffered.
-	///
-	/// # Arguments
-	///
-	/// `n` The maximum number of messages that can be buffered. Setting this
-	///     to zero disables off-line buffering.
-	///
-	pub fn max_buffered_messages(mut self, n: i32) -> Self {
-		self.copts.maxBufferedMessages = n;
-		self.copts.sendWhileDisconnected = if n == 0 { 0 } else { 1 };
-		self
-	}
+    /// Sets the maximum number of messages that can be buffered for delivery
+    /// when the client is off-line.
+    /// The client has limited support for bufferering messages when the
+    /// client is temporarily disconnected. This specifies the maximum number
+    /// of messages that can be buffered.
+    ///
+    /// # Arguments
+    ///
+    /// `n` The maximum number of messages that can be buffered. Setting this
+    ///     to zero disables off-line buffering.
+    ///
+    pub fn max_buffered_messages(mut self, n: i32) -> Self {
+        self.copts.maxBufferedMessages = n;
+        self.copts.sendWhileDisconnected = if n == 0 { 0 } else { 1 };
+        self
+    }
 
     /// Sets the version of MQTT to use on the connect.
     ///
@@ -281,16 +281,16 @@ impl CreateOptionsBuilder {
         self
     }
 
-	/// Constructs a set of create options from the builder information.
-	pub fn finalize(self) -> CreateOptions {
-		CreateOptions {
-			copts: self.copts,
-			server_uri: self.server_uri,
-			client_id: self.client_id,
-			persistence: self.persistence,
+    /// Constructs a set of create options from the builder information.
+    pub fn finalize(self) -> CreateOptions {
+        CreateOptions {
+            copts: self.copts,
+            server_uri: self.server_uri,
+            client_id: self.client_id,
+            persistence: self.persistence,
             user_data: self.user_data,
-		}
-	}
+        }
+    }
 
     /// Finalize the builder and create an asynchronous client.
     pub fn create_client(self) -> Result<AsyncClient> {
@@ -304,112 +304,127 @@ impl CreateOptionsBuilder {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-    use std::os::raw::{c_char};
+    use super::*;
+    use std::os::raw::c_char;
 
     // The currently supported MQTTAsync_createOptions::struct_version
     const STRUCT_VER: c_int = 1;
 
     // The identifier for the create options structure
-    const STRUCT_ID: [c_char; 4] = [ b'M' as c_char, b'Q' as c_char, b'C' as c_char, b'O' as c_char];
+    const STRUCT_ID: [c_char; 4] = [
+        b'M' as c_char,
+        b'Q' as c_char,
+        b'C' as c_char,
+        b'O' as c_char,
+    ];
 
-	// Rust options should be the same as the C options
-	#[test]
-	fn test_default() {
-		let opts = CreateOptions::default();
-		// Get default C options for comparison
-		let copts = ffi::MQTTAsync_createOptions::default();
+    // Rust options should be the same as the C options
+    #[test]
+    fn test_default() {
+        let opts = CreateOptions::default();
+        // Get default C options for comparison
+        let copts = ffi::MQTTAsync_createOptions::default();
 
-		// First, make sure C options valid
+        // First, make sure C options valid
         assert_eq!(STRUCT_ID, copts.struct_id);
-		assert_eq!(STRUCT_VER, copts.struct_version);
+        assert_eq!(STRUCT_VER, copts.struct_version);
 
-		assert_eq!(copts.struct_id, opts.copts.struct_id);
-		assert_eq!(copts.struct_version, opts.copts.struct_version);
-		assert_eq!(copts.sendWhileDisconnected, opts.copts.sendWhileDisconnected);
-		assert_eq!(copts.maxBufferedMessages, opts.copts.maxBufferedMessages);
+        assert_eq!(copts.struct_id, opts.copts.struct_id);
+        assert_eq!(copts.struct_version, opts.copts.struct_version);
+        assert_eq!(
+            copts.sendWhileDisconnected,
+            opts.copts.sendWhileDisconnected
+        );
+        assert_eq!(copts.maxBufferedMessages, opts.copts.maxBufferedMessages);
 
-		assert_eq!("", &opts.server_uri);
-		assert_eq!("", &opts.client_id);
-		//assert_eq!(PersistenceType::default(), opts.persistence);
-	}
+        assert_eq!("", &opts.server_uri);
+        assert_eq!("", &opts.client_id);
+        //assert_eq!(PersistenceType::default(), opts.persistence);
+    }
 
-	#[test]
-	fn test_from_string() {
-		const HOST: &str = "localhost";
+    #[test]
+    fn test_from_string() {
+        const HOST: &str = "localhost";
 
         let opts = CreateOptions::from(HOST);
-		let copts = ffi::MQTTAsync_createOptions::default();
+        let copts = ffi::MQTTAsync_createOptions::default();
 
-		assert_eq!(STRUCT_ID, opts.copts.struct_id);
-		assert_eq!(STRUCT_VER, opts.copts.struct_version);
-		assert_eq!(copts.sendWhileDisconnected, opts.copts.sendWhileDisconnected);
-		assert_eq!(copts.maxBufferedMessages, opts.copts.maxBufferedMessages);
+        assert_eq!(STRUCT_ID, opts.copts.struct_id);
+        assert_eq!(STRUCT_VER, opts.copts.struct_version);
+        assert_eq!(
+            copts.sendWhileDisconnected,
+            opts.copts.sendWhileDisconnected
+        );
+        assert_eq!(copts.maxBufferedMessages, opts.copts.maxBufferedMessages);
 
-		assert_eq!(HOST, &opts.server_uri);
-		assert_eq!("", &opts.client_id);
-		//assert_eq!(PersistenceType::File, opts.persistence);
-	}
+        assert_eq!(HOST, &opts.server_uri);
+        assert_eq!("", &opts.client_id);
+        //assert_eq!(PersistenceType::File, opts.persistence);
+    }
 
+    #[test]
+    fn test_from_tuple() {
+        const HOST: &str = "localhost";
+        const ID: &str = "bubba";
 
-	#[test]
-	fn test_from_tuple() {
-		const HOST: &str = "localhost";
-		const ID: &str = "bubba";
+        let opts = CreateOptions::from((HOST, ID));
+        let copts = ffi::MQTTAsync_createOptions::default();
 
-        let opts = CreateOptions::from((HOST,ID));
-		let copts = ffi::MQTTAsync_createOptions::default();
+        assert_eq!(STRUCT_ID, opts.copts.struct_id);
+        assert_eq!(STRUCT_VER, opts.copts.struct_version);
+        assert_eq!(
+            copts.sendWhileDisconnected,
+            opts.copts.sendWhileDisconnected
+        );
+        assert_eq!(copts.maxBufferedMessages, opts.copts.maxBufferedMessages);
 
-		assert_eq!(STRUCT_ID, opts.copts.struct_id);
-		assert_eq!(STRUCT_VER, opts.copts.struct_version);
-		assert_eq!(copts.sendWhileDisconnected, opts.copts.sendWhileDisconnected);
-		assert_eq!(copts.maxBufferedMessages, opts.copts.maxBufferedMessages);
+        assert_eq!(HOST, &opts.server_uri);
+        assert_eq!(ID, &opts.client_id);
+        //assert_eq!(PersistenceType::File, opts.persistence);
+    }
 
-		assert_eq!(HOST, &opts.server_uri);
-		assert_eq!(ID, &opts.client_id);
-		//assert_eq!(PersistenceType::File, opts.persistence);
-	}
+    #[test]
+    fn test_default_builder() {
+        let opts = CreateOptionsBuilder::new().finalize();
+        let copts = ffi::MQTTAsync_createOptions::default();
 
-	#[test]
-	fn test_default_builder() {
-		let opts = CreateOptionsBuilder::new().finalize();
-		let copts = ffi::MQTTAsync_createOptions::default();
+        // First, make sure C options valid
+        assert_eq!(STRUCT_ID, copts.struct_id);
+        assert_eq!(STRUCT_VER, copts.struct_version);
 
-		// First, make sure C options valid
-		assert_eq!(STRUCT_ID, copts.struct_id);
-		assert_eq!(STRUCT_VER, copts.struct_version);
+        assert_eq!(copts.struct_id, opts.copts.struct_id);
+        assert_eq!(copts.struct_version, opts.copts.struct_version);
+        assert_eq!(
+            copts.sendWhileDisconnected,
+            opts.copts.sendWhileDisconnected
+        );
+        assert_eq!(copts.maxBufferedMessages, opts.copts.maxBufferedMessages);
 
-		assert_eq!(copts.struct_id, opts.copts.struct_id);
-		assert_eq!(copts.struct_version, opts.copts.struct_version);
-		assert_eq!(copts.sendWhileDisconnected, opts.copts.sendWhileDisconnected);
-		assert_eq!(copts.maxBufferedMessages, opts.copts.maxBufferedMessages);
+        assert_eq!("", &opts.server_uri);
+        assert_eq!("", &opts.client_id);
+        //assert_eq!(PersistenceType::File, opts.persistence);
+    }
 
-		assert_eq!("", &opts.server_uri);
-		assert_eq!("", &opts.client_id);
-		//assert_eq!(PersistenceType::File, opts.persistence);
-	}
+    #[test]
+    fn test_builder() {
+        const HOST: &str = "localhost";
+        const ID: &str = "bubba";
+        const MAX_BUF_MSGS: i32 = 100;
 
-	#[test]
-	fn test_builder() {
-		const HOST: &str = "localhost";
-		const ID: &str = "bubba";
-		const MAX_BUF_MSGS: i32 = 100;
+        let opts = CreateOptionsBuilder::new()
+            .server_uri(HOST)
+            .client_id(ID)
+            // TODO: Test persistence
+            .max_buffered_messages(MAX_BUF_MSGS)
+            .finalize();
 
-		let opts = CreateOptionsBuilder::new()
-						.server_uri(HOST)
-						.client_id(ID)
-						// TODO: Test persistence
-						.max_buffered_messages(MAX_BUF_MSGS)
-						.finalize();
+        assert_eq!(STRUCT_ID, opts.copts.struct_id);
+        assert_eq!(STRUCT_VER, opts.copts.struct_version);
 
-		assert_eq!(STRUCT_ID, opts.copts.struct_id);
-		assert_eq!(STRUCT_VER, opts.copts.struct_version);
-
-		assert_eq!(HOST, &opts.server_uri);
-		assert_eq!(ID, &opts.client_id);
-		//assert_eq!(PersistenceType::File, opts.persistence);
-		assert!(0 != opts.copts.sendWhileDisconnected);
-		assert_eq!(MAX_BUF_MSGS, opts.copts.maxBufferedMessages);
-	}
+        assert_eq!(HOST, &opts.server_uri);
+        assert_eq!(ID, &opts.client_id);
+        //assert_eq!(PersistenceType::File, opts.persistence);
+        assert!(0 != opts.copts.sendWhileDisconnected);
+        assert_eq!(MAX_BUF_MSGS, opts.copts.maxBufferedMessages);
+    }
 }
-

--- a/src/disconnect_options.rs
+++ b/src/disconnect_options.rs
@@ -29,9 +29,9 @@ use std::time::Duration;
 
 use crate::{
     ffi,
-    token::{Token, TokenInner},
-    reason_code::ReasonCode,
     properties::Properties,
+    reason_code::ReasonCode,
+    token::{Token, TokenInner},
 };
 
 /// The collection of options for disconnecting from the client.
@@ -86,10 +86,7 @@ impl Default for DisconnectOptions {
 
 impl Clone for DisconnectOptions {
     fn clone(&self) -> Self {
-        Self::from_data(
-            self.copts.clone(),
-            self.props.clone()
-        )
+        Self::from_data(self.copts.clone(), self.props.clone())
     }
 }
 
@@ -156,10 +153,7 @@ impl DisconnectOptionsBuilder {
 
     /// Finalize the builder to create the disconnect options.
     pub fn finalize(&self) -> DisconnectOptions {
-        DisconnectOptions::from_data(
-            self.copts.clone(),
-            self.props.clone()
-        )
+        DisconnectOptions::from_data(self.copts.clone(), self.props.clone())
     }
 }
 
@@ -170,17 +164,19 @@ impl DisconnectOptionsBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{properties::PropertyCode, reason_code::NormalDisconnection};
     use std::{
-        thread,
         os::raw::{c_char, c_int},
-    };
-    use crate::{
-        reason_code::NormalDisconnection,
-        properties::PropertyCode,
+        thread,
     };
 
     // Identifier fo a C disconnect options struct
-    const STRUCT_ID: [c_char; 4] = [ b'M' as c_char, b'Q' as c_char, b'T' as c_char, b'D' as c_char ];
+    const STRUCT_ID: [c_char; 4] = [
+        b'M' as c_char,
+        b'Q' as c_char,
+        b'T' as c_char,
+        b'D' as c_char,
+    ];
     const STRUCT_VERSION: c_int = 1;
 
     #[test]
@@ -229,31 +225,41 @@ mod tests {
         assert_eq!(opts.properties().len(), 0);
 
         let mut props = Properties::new();
-        props.push_int(PropertyCode::SessionExpiryInterval, 1000).unwrap();
-        props.push_val(PropertyCode::ReasonString, "causeIwanna").unwrap();
+        props
+            .push_int(PropertyCode::SessionExpiryInterval, 1000)
+            .unwrap();
+        props
+            .push_val(PropertyCode::ReasonString, "causeIwanna")
+            .unwrap();
 
-        let opts = DisconnectOptionsBuilder::new()
-            .properties(props)
-            .finalize();
+        let opts = DisconnectOptionsBuilder::new().properties(props).finalize();
 
         let props = opts.properties();
 
         assert!(!props.is_empty());
         assert_eq!(props.len(), 2);
 
-        assert_eq!(props.get_int(PropertyCode::SessionExpiryInterval), Some(1000));
-        assert_eq!(props.get_val::<String>(PropertyCode::ReasonString),
-                   Some("causeIwanna".to_string()));
+        assert_eq!(
+            props.get_int(PropertyCode::SessionExpiryInterval),
+            Some(1000)
+        );
+        assert_eq!(
+            props.get_val::<String>(PropertyCode::ReasonString),
+            Some("causeIwanna".to_string())
+        );
 
         assert_eq!(props.get_int(PropertyCode::ContentType), None);
 
         let props = Properties::from_c_struct(&opts.copts.properties);
         assert_eq!(props.len(), 2);
 
-        assert_eq!(props.get_int(PropertyCode::SessionExpiryInterval), Some(1000));
-        assert_eq!(props.get_val::<String>(PropertyCode::ReasonString),
-                   Some("causeIwanna".to_string()));
-
+        assert_eq!(
+            props.get_int(PropertyCode::SessionExpiryInterval),
+            Some(1000)
+        );
+        assert_eq!(
+            props.get_val::<String>(PropertyCode::ReasonString),
+            Some("causeIwanna".to_string())
+        );
     }
 }
-

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -17,16 +17,9 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{
-    io,
-    result,
-    str,
-};
+use crate::{ffi, reason_code::ReasonCode};
+use std::{io, result, str};
 use thiserror::Error;
-use crate::{
-    ffi,
-    reason_code::ReasonCode,
-};
 
 /// The errors from an MQTT operation.
 #[derive(Error, Debug)]
@@ -92,7 +85,6 @@ pub fn error_message(rc: i32) -> &'static str {
         ffi::MQTTASYNC_BAD_MQTT_OPTION => "Bad option",
         ffi::MQTTASYNC_WRONG_MQTT_VERSION => "Wrong MQTT version",
         ffi::MQTTASYNC_0_LEN_WILL_TOPIC => "Zero length Will Topic",
-         _ => "Unknown Error",
+        _ => "Unknown Error",
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,36 +28,33 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-
 // Temporary
 #![allow(dead_code)]
 
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate paho_mqtt_sys as ffi;
 
-pub use crate::async_client::*;        //{AsyncClient, AsyncClientBuilder};
-pub use crate::client::*;              //{Client, ClientBuilder};
-pub use crate::create_options::*;      //{CreateOptions, CreateOptionsBuilder};
-pub use crate::connect_options::*;     //{ConnectOptions, ConnectOptionsBuilder, MQTT_VERSION_3_1_1, ...};
-pub use crate::will_options::*;        //{WillOptions, WillOptionsBuilder};
-pub use crate::ssl_options::*;         //{SslOptions, SslOptionsBuilder};
-pub use crate::disconnect_options::*;  //{DisconnectOptions, DisconnectOptionsBuilder};
-pub use crate::subscribe_options::*;   //{SubscribeOptions};
-pub use crate::response_options::*;    //{ResponseOptions};
-pub use crate::server_response::*;     //{ServerResponse, CommandResponse};
-pub use crate::properties::*;          //{Property, Properties};
-pub use crate::message::*;             //{Message, MessageBuilder};
-pub use crate::token::*;               //{Token}
-pub use crate::topic::*;               //{Topic}
-pub use crate::reason_code::*;         //{ReasonCode}
-pub use crate::types::*;               //...
+pub use crate::async_client::*; //{AsyncClient, AsyncClientBuilder};
+pub use crate::client::*; //{Client, ClientBuilder};
 pub use crate::client_persistence::*;
-pub use crate::errors::*;              //{Result, Error, ErrorKind};
+pub use crate::connect_options::*; //{ConnectOptions, ConnectOptionsBuilder, MQTT_VERSION_3_1_1, ...};
+pub use crate::create_options::*; //{CreateOptions, CreateOptionsBuilder};
+pub use crate::disconnect_options::*; //{DisconnectOptions, DisconnectOptionsBuilder};
+pub use crate::errors::*;
+pub use crate::message::*; //{Message, MessageBuilder};
+pub use crate::properties::*; //{Property, Properties};
+pub use crate::reason_code::*; //{ReasonCode}
+pub use crate::response_options::*; //{ResponseOptions};
+pub use crate::server_response::*; //{ServerResponse, CommandResponse};
+pub use crate::ssl_options::*; //{SslOptions, SslOptionsBuilder};
+pub use crate::subscribe_options::*; //{SubscribeOptions};
+pub use crate::token::*; //{Token}
+pub use crate::topic::*; //{Topic}
+pub use crate::types::*; //...
+pub use crate::will_options::*; //{WillOptions, WillOptionsBuilder}; //{Result, Error, ErrorKind};
 
-use std::{
-    os::raw::c_int,
-    any::Any,
-};
+use std::{any::Any, os::raw::c_int};
 
 mod macros;
 
@@ -131,12 +128,15 @@ pub mod name_value;
 /// client as "user data" to be accessed from callbacks, etc.
 pub type UserData = Box<dyn Any + 'static + Send + Sync>;
 
-
 // --------------------------------------------------------------------------
 
 /// Convert a Rust bool to a Paho C boolean
 pub fn to_c_bool(on: bool) -> c_int {
-    if on { 1 } else { 0 }
+    if on {
+        1
+    } else {
+        0
+    }
 }
 
 /// Converts a C integer boolean to a Rust bool

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,5 @@
 // macros.rs
-// 
+//
 // This file is part of the Eclipse Paho MQTT Rust Client library.
 //
 // This contains the macro definitions for the crate.
@@ -23,12 +23,12 @@
 
 #![macro_use]
 
-/// Return an error from a function. 
+/// Return an error from a function.
 
 macro_rules! bail {
-    ($expr:expr) => (
+    ($expr:expr) => {
         return Err(::std::convert::From::from($expr));
-    )
+    };
 }
 
 #[macro_export]
@@ -45,4 +45,3 @@ macro_rules! properties(
         properties![ $( $key => $value ),* ]
     };
 );
-

--- a/src/name_value.rs
+++ b/src/name_value.rs
@@ -25,10 +25,7 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{
-    ffi::CString,
-    pin::Pin,
-};
+use std::{ffi::CString, pin::Pin};
 
 /// The name/value pointer pair from the C library.
 type CNameValue = ffi::MQTTAsync_nameValue;
@@ -54,17 +51,17 @@ struct NameValueData {
     coll: Vec<(CString, CString)>,
 }
 
-impl NameValueCollection
-{
+impl NameValueCollection {
     /// Creates a NameValueCollection from a vector of string pair references.
     ///
     /// # Arguments
     ///
     /// `coll` A collection of string pair references.
     ///
-    pub fn new<N,V>(coll: &[(N,V)]) -> Self
-        where N: AsRef<str>,
-              V: AsRef<str>,
+    pub fn new<N, V>(coll: &[(N, V)]) -> Self
+    where
+        N: AsRef<str>,
+        V: AsRef<str>,
     {
         let data = NameValueData {
             coll: Self::to_cstring_pair(coll),
@@ -73,15 +70,18 @@ impl NameValueCollection
     }
 
     // Convert a collection of string references to a vector of CString pairs.
-    fn to_cstring_pair<N,V>(coll: &[(N,V)]) -> Vec<(CString, CString)>
-        where N: AsRef<str>,
-              V: AsRef<str>
+    fn to_cstring_pair<N, V>(coll: &[(N, V)]) -> Vec<(CString, CString)>
+    where
+        N: AsRef<str>,
+        V: AsRef<str>,
     {
         coll.iter()
-            .map(|p| (
-                CString::new(p.0.as_ref()).unwrap(),
-                CString::new(p.1.as_ref()).unwrap()
-            ))
+            .map(|p| {
+                (
+                    CString::new(p.0.as_ref()).unwrap(),
+                    CString::new(p.1.as_ref()).unwrap(),
+                )
+            })
             .collect()
     }
 
@@ -95,7 +95,8 @@ impl NameValueCollection
     // Note that the pointers are invalidated if the original vector or
     // any of the strings in it change.
     fn to_c_vec(sv: &[(CString, CString)]) -> Vec<CNameValue> {
-        let mut coll: Vec<CNameValue> = sv.iter()
+        let mut coll: Vec<CNameValue> = sv
+            .iter()
             .map(|csp| CNameValue::new(csp.0.as_ptr(), csp.1.as_ptr()))
             .collect();
         coll.push(CNameValue::default());
@@ -110,7 +111,9 @@ impl NameValueCollection
     }
 
     /// Gets the number of strings in the collection.
-    pub fn len(&self) -> usize { self.data.coll.len() }
+    pub fn len(&self) -> usize {
+        self.data.coll.len()
+    }
 
     /// Gets the collection as a pointer to const C string pair pointers.
     ///
@@ -126,15 +129,13 @@ impl NameValueCollection
     }
 }
 
-impl Default for NameValueCollection
-{
+impl Default for NameValueCollection {
     fn default() -> Self {
         Self::from_data(NameValueData::default())
     }
 }
 
-impl Clone for NameValueCollection
-{
+impl Clone for NameValueCollection {
     fn clone(&self) -> Self {
         Self::from_data((&*self.data).clone())
     }
@@ -166,7 +167,7 @@ mod tests {
         let sc = NameValueCollection::new(&v);
 
         assert_eq!(n, sc.len());
-        assert_eq!(n+1, sc.c_coll.len());
+        assert_eq!(n + 1, sc.c_coll.len());
         assert_eq!(n, sc.data.coll.len());
 
         assert_eq!(v[0].0.as_bytes(), sc.data.coll[0].0.as_bytes());
@@ -197,7 +198,7 @@ mod tests {
         let sc = NameValueCollection::new(&v);
 
         assert_eq!(n, sc.len());
-        assert_eq!(n+1, sc.c_coll.len());
+        assert_eq!(n + 1, sc.c_coll.len());
         assert_eq!(n, sc.data.coll.len());
 
         assert_eq!(v[0].0.as_bytes(), sc.data.coll[0].0.as_bytes());
@@ -229,7 +230,7 @@ mod tests {
         let sc = org_sc;
 
         assert_eq!(n, sc.len());
-        assert_eq!(n+1, sc.c_coll.len());
+        assert_eq!(n + 1, sc.c_coll.len());
         assert_eq!(n, sc.data.coll.len());
 
         assert_eq!(v[0].0.as_bytes(), sc.data.coll[0].0.as_bytes());
@@ -262,7 +263,7 @@ mod tests {
         };
 
         assert_eq!(n, sc.len());
-        assert_eq!(n+1, sc.c_coll.len());
+        assert_eq!(n + 1, sc.c_coll.len());
         assert_eq!(n, sc.data.coll.len());
 
         assert_eq!(v[0].0.as_bytes(), sc.data.coll[0].0.as_bytes());
@@ -284,4 +285,3 @@ mod tests {
         assert_eq!(sc.data.coll[2].1.as_ptr(), sc.c_coll[2].value);
     }
 }
-

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -24,17 +24,14 @@
 //! MQTT v5 properties.
 
 use std::{
-    mem,
-    ptr,
-    ffi::CString,
-    os::raw::{c_int, c_char},
     any::{Any, TypeId},
+    ffi::CString,
+    mem,
+    os::raw::{c_char, c_int},
+    ptr,
 };
 
-use crate::{
-    ffi,
-    errors::Result,
-};
+use crate::{errors::Result, ffi};
 
 /// Error code for property mismatches
 const INVALID_PROPERTY_ID: i32 = ffi::MQTT_INVALID_PROPERTY_ID;
@@ -47,7 +44,6 @@ pub type Value = ffi::MQTTProperty__bindgen_ty_1;
 
 /// The struct to encapsulate property string values.
 type LenString = ffi::MQTTLenString;
-
 
 #[repr(u32)]
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -75,7 +71,7 @@ impl PropertyType {
             4 => Some(Self::BinaryData),
             5 => Some(Self::Utf8EncodedString),
             6 => Some(Self::Utf8StringPair),
-            _ => None
+            _ => None,
         }
     }
 
@@ -88,11 +84,10 @@ impl PropertyType {
             Self::VariableByteInteger => TypeId::of::<i32>(),
             Self::BinaryData => TypeId::of::<Binary>(),
             Self::Utf8EncodedString => TypeId::of::<String>(),
-            Self::Utf8StringPair => TypeId::of::<(String,String)>(),
+            Self::Utf8StringPair => TypeId::of::<(String, String)>(),
         }
     }
 }
-
 
 /// The enumerated codes for the MQTT v5 properties.
 ///
@@ -137,11 +132,11 @@ type Code = ffi::MQTTPropertyCodes;
 impl PropertyCode {
     pub fn new(code: ffi::MQTTPropertyCodes) -> Option<Self> {
         match code {
-             1 => Some(Self::PayloadFormatIndicator),
-             2 => Some(Self::MessageExpiryInterval),
-             3 => Some(Self::ContentType),
-             8 => Some(Self::ResponseTopic),
-             9 => Some(Self::CorrelationData),
+            1 => Some(Self::PayloadFormatIndicator),
+            2 => Some(Self::MessageExpiryInterval),
+            3 => Some(Self::ContentType),
+            8 => Some(Self::ResponseTopic),
+            9 => Some(Self::CorrelationData),
             11 => Some(Self::SubscriptionIdentifier),
             17 => Some(Self::SessionExpiryInterval),
             18 => Some(Self::AssignedClientIdentifer),
@@ -164,7 +159,7 @@ impl PropertyCode {
             40 => Some(Self::WildcardSubscriptionAvailable),
             41 => Some(Self::SubscriptionIdentifiersAvailable),
             42 => Some(Self::SharedSubscriptionAvailable),
-            _ => None
+            _ => None,
         }
     }
 
@@ -211,7 +206,8 @@ impl Property {
     /// The type for the value must match the type expected for the given
     /// property code exactly, otherwise it will be rejected and return None.
     pub fn new<T>(code: PropertyCode, val: T) -> Result<Property>
-        where T: Any + 'static
+    where
+        T: Any + 'static,
     {
         let rval: &(dyn Any + 'static) = &val;
 
@@ -221,8 +217,7 @@ impl Property {
             // A binary type can accept strings
             if let Some(v) = rval.downcast_ref::<&str>() {
                 return Self::new_binary(code, v.as_bytes());
-            }
-            else if let Some(v) = rval.downcast_ref::<String>() {
+            } else if let Some(v) = rval.downcast_ref::<String>() {
                 return Self::new_binary(code, v.as_bytes());
             }
         }
@@ -236,140 +231,95 @@ impl Property {
 
         if let Some(v) = rval.downcast_ref::<u8>() {
             Self::new_byte(code, *v)
-        }
-        else if let Some(v) = rval.downcast_ref::<u16>() {
+        } else if let Some(v) = rval.downcast_ref::<u16>() {
             Self::new_u16(code, *v)
-        }
-        else if let Some(v) = rval.downcast_ref::<i16>() {
+        } else if let Some(v) = rval.downcast_ref::<i16>() {
             Self::new_u16(code, *v as u16)
-        }
-        else if let Some(v) = rval.downcast_ref::<u32>() {
+        } else if let Some(v) = rval.downcast_ref::<u32>() {
             Self::new_u32(code, *v)
-        }
-        else if let Some(v) = rval.downcast_ref::<i32>() {
+        } else if let Some(v) = rval.downcast_ref::<i32>() {
             Self::new_int(code, *v)
-        }
-        else if let Some(v) = rval.downcast_ref::<Binary>() {
+        } else if let Some(v) = rval.downcast_ref::<Binary>() {
             Self::new_binary(code, v.clone())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8]>() {
             return Self::new_binary(code, *v);
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 1]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 1]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 2]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 2]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 3]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 3]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 4]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 4]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 5]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 5]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 6]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 6]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 7]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 7]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 8]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 8]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 9]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 9]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 10]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 10]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 11]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 11]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 12]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 12]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 13]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 13]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 14]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 14]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 15]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 15]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 16]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 16]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 17]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 17]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 18]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 18]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 19]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 19]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 20]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 20]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 21]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 21]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 22]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 22]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 23]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 23]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 24]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 24]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 25]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 25]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 26]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 26]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 27]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 27]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 28]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 28]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 29]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 29]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 30]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 30]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 31]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 31]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<&[u8 ; 32]>() {
+        } else if let Some(v) = rval.downcast_ref::<&[u8; 32]>() {
             Self::new_binary(code, v.to_vec())
-        }
-        else if let Some(v) = rval.downcast_ref::<String>() {
+        } else if let Some(v) = rval.downcast_ref::<String>() {
             Self::new_string(code, &*v)
-        }
-        else if let Some(v) = rval.downcast_ref::<&str>() {
+        } else if let Some(v) = rval.downcast_ref::<&str>() {
             return Self::new_string(code, v);
-        }
-        else if let Some(v) = rval.downcast_ref::<(String,String)>() {
+        } else if let Some(v) = rval.downcast_ref::<(String, String)>() {
             Self::new_string_pair(code, &v.0, &v.1)
-        }
-        else if let Some(v) = rval.downcast_ref::<(&str, &str)>() {
+        } else if let Some(v) = rval.downcast_ref::<(&str, &str)>() {
             Self::new_string_pair(code, v.0, v.1)
-        }
-        else if let Some(v) = rval.downcast_ref::<(&str, String)>() {
+        } else if let Some(v) = rval.downcast_ref::<(&str, String)>() {
             Self::new_string_pair(code, v.0, &v.1)
-        }
-        else if let Some(v) = rval.downcast_ref::<(String, &str)>() {
+        } else if let Some(v) = rval.downcast_ref::<(String, &str)>() {
             Self::new_string_pair(code, &v.0, v.1)
-        }
-        else {
+        } else {
             Err(INVALID_PROPERTY_ID.into())
         }
     }
@@ -393,7 +343,7 @@ impl Property {
     /// Creates a 4-byte integer property
     pub fn new_u32(code: PropertyCode, val: u32) -> Result<Property> {
         match code.property_type() {
-            PropertyType::FourByteInteger =>  Self::new_int(code, val as i32),
+            PropertyType::FourByteInteger => Self::new_int(code, val as i32),
             _ => Err(INVALID_PROPERTY_ID.into()),
         }
     }
@@ -404,15 +354,22 @@ impl Property {
     pub fn new_int(code: PropertyCode, val: i32) -> Result<Property> {
         let value = match code.property_type() {
             PropertyType::Byte => {
-                if val & !0xFF != 0 { bail!(INVALID_PROPERTY_ID); }
+                if val & !0xFF != 0 {
+                    bail!(INVALID_PROPERTY_ID);
+                }
                 Value { byte: val as u8 }
-            },
+            }
             PropertyType::TwoByteInteger => {
-                if val & !0xFFFF != 0 { return Err(INVALID_PROPERTY_ID.into()); }
-                Value { integer2: val as u16 }
+                if val & !0xFFFF != 0 {
+                    return Err(INVALID_PROPERTY_ID.into());
+                }
+                Value {
+                    integer2: val as u16,
+                }
+            }
+            PropertyType::FourByteInteger | PropertyType::VariableByteInteger => Value {
+                integer4: val as u32,
             },
-            PropertyType::FourByteInteger | PropertyType::VariableByteInteger =>
-                Value { integer4: val as u32 },
             _ => return Err(INVALID_PROPERTY_ID.into()),
         };
 
@@ -420,13 +377,14 @@ impl Property {
             cprop: ffi::MQTTProperty {
                 identifier: code as Code,
                 value,
-            }
+            },
         })
     }
 
     /// Creates a new binary property.
     pub fn new_binary<V>(code: PropertyCode, bin: V) -> Result<Property>
-        where V: Into<Binary>
+    where
+        V: Into<Binary>,
     {
         if code.property_type() != PropertyType::BinaryData {
             return Err(INVALID_PROPERTY_ID.into());
@@ -472,10 +430,9 @@ impl Property {
     /// Creates a property from a C lib MQTTProperty struct.
     fn from_c_property(cprop: &ffi::MQTTProperty) -> Result<Property> {
         let mut cprop = cprop.clone();
-        let typ = match PropertyCode::new(cprop.identifier)
-                    .and_then(|c| Some(c.property_type())) {
+        let typ = match PropertyCode::new(cprop.identifier).and_then(|c| Some(c.property_type())) {
             Some(typ) => typ,
-            None => return Err(INVALID_PROPERTY_ID.into())
+            None => return Err(INVALID_PROPERTY_ID.into()),
         };
 
         unsafe {
@@ -484,21 +441,27 @@ impl Property {
 
             match typ {
                 PropertyType::BinaryData => {
-                    if pdata.is_null() { return Err(INVALID_PROPERTY_ID.into()); }
+                    if pdata.is_null() {
+                        return Err(INVALID_PROPERTY_ID.into());
+                    }
                     let v = Vec::from_raw_parts(pdata, n, n);
                     let mut vc = v.clone();
                     pdata = vc.as_mut_ptr() as *mut c_char;
                     mem::forget(v);
                     mem::forget(vc);
-                },
+                }
                 PropertyType::Utf8EncodedString => {
-                    if pdata.is_null() { return Err(INVALID_PROPERTY_ID.into()); }
+                    if pdata.is_null() {
+                        return Err(INVALID_PROPERTY_ID.into());
+                    }
                     let v = Vec::from_raw_parts(pdata as *mut u8, n, n);
                     let sr = CString::new(v.clone());
-                    if sr.is_err() { return Err(INVALID_PROPERTY_ID.into()); }
+                    if sr.is_err() {
+                        return Err(INVALID_PROPERTY_ID.into());
+                    }
                     pdata = sr.unwrap().into_raw();
                     mem::forget(v);
-                },
+                }
                 PropertyType::Utf8StringPair => {
                     let pvalue = cprop.value.__bindgen_anon_1.value.data;
                     if pdata.is_null() || pvalue.is_null() {
@@ -507,25 +470,28 @@ impl Property {
 
                     let v = Vec::from_raw_parts(pdata as *mut u8, n, n);
                     let sr = CString::new(v.clone());
-                    if sr.is_err() { return Err(INVALID_PROPERTY_ID.into()); }
+                    if sr.is_err() {
+                        return Err(INVALID_PROPERTY_ID.into());
+                    }
                     pdata = sr.unwrap().into_raw();
                     mem::forget(v);
 
                     let n = cprop.value.__bindgen_anon_1.value.len as usize;
                     let v = Vec::from_raw_parts(pvalue as *mut u8, n, n);
                     let sr = CString::new(v.clone());
-                    if sr.is_err() { return Err(INVALID_PROPERTY_ID.into()); }
+                    if sr.is_err() {
+                        return Err(INVALID_PROPERTY_ID.into());
+                    }
                     cprop.value.__bindgen_anon_1.value.data = sr.unwrap().into_raw();
                     mem::forget(v);
-                },
+                }
                 _ => (),
             }
 
             // Lengths are the same as the originals
             cprop.value.__bindgen_anon_1.data.data = pdata;
-
         }
-        Ok(Property { cprop, })
+        Ok(Property { cprop })
     }
 
     /// Creates a new string, string pair, or binary property given the raw
@@ -533,8 +499,13 @@ impl Property {
     /// This is a low-level, internal call to create a preperty that contains
     /// dynamic data. It does no error checking; it simply assembles the
     /// struct.
-    fn new_string_binary(code: PropertyCode, pdata: *mut c_char, ndata: usize,
-                         pval: *mut c_char, nval: usize) -> Property {
+    fn new_string_binary(
+        code: PropertyCode,
+        pdata: *mut c_char,
+        ndata: usize,
+        pval: *mut c_char,
+        nval: usize,
+    ) -> Property {
         Property {
             cprop: ffi::MQTTProperty {
                 identifier: code as Code,
@@ -571,7 +542,8 @@ impl Property {
 
     /// Gets the property value
     pub fn get<T>(&self) -> Option<T>
-        where T: Any + 'static + Send + Default
+    where
+        T: Any + 'static + Send + Default,
     {
         let mut v = T::default();
         let x: &mut dyn Any = &mut v;
@@ -581,38 +553,32 @@ impl Property {
                 *val = n;
                 return Some(v);
             }
-        }
-        else if let Some(val) = x.downcast_mut::<u16>() {
+        } else if let Some(val) = x.downcast_mut::<u16>() {
             if let Some(n) = self.get_u16() {
                 *val = n;
                 return Some(v);
             }
-        }
-        else if let Some(val) = x.downcast_mut::<u32>() {
+        } else if let Some(val) = x.downcast_mut::<u32>() {
             if let Some(n) = self.get_u32() {
                 *val = n;
                 return Some(v);
             }
-        }
-        else if let Some(val) = x.downcast_mut::<i32>() {
+        } else if let Some(val) = x.downcast_mut::<i32>() {
             if let Some(n) = self.get_int() {
                 *val = n;
                 return Some(v);
             }
-        }
-        else if let Some(val) = x.downcast_mut::<Binary>() {
+        } else if let Some(val) = x.downcast_mut::<Binary>() {
             if let Some(n) = self.get_binary() {
                 *val = n;
                 return Some(v);
             }
-        }
-        else if let Some(val) = x.downcast_mut::<String>() {
+        } else if let Some(val) = x.downcast_mut::<String>() {
             if let Some(n) = self.get_string() {
                 *val = n;
                 return Some(v);
             }
-        }
-        else if let Some(val) = x.downcast_mut::<(String,String)>() {
+        } else if let Some(val) = x.downcast_mut::<(String, String)>() {
             if let Some(n) = self.get_string_pair() {
                 *val = n;
                 return Some(v);
@@ -625,25 +591,23 @@ impl Property {
     pub fn get_byte(&self) -> Option<u8> {
         match self.property_type() {
             PropertyType::Byte => Some(unsafe { self.cprop.value.byte }),
-            _ => None
+            _ => None,
         }
     }
 
     /// Gets the property value as a u16.
     pub fn get_u16(&self) -> Option<u16> {
         match self.property_type() {
-            PropertyType::TwoByteInteger =>
-                Some(unsafe { self.cprop.value.integer2 }),
-            _ => None
+            PropertyType::TwoByteInteger => Some(unsafe { self.cprop.value.integer2 }),
+            _ => None,
         }
     }
 
     /// Gets the property value as a u16.
     pub fn get_u32(&self) -> Option<u32> {
         match self.property_type() {
-            PropertyType::FourByteInteger =>
-                Some(unsafe { self.cprop.value.integer4 }),
-            _ => None
+            PropertyType::FourByteInteger => Some(unsafe { self.cprop.value.integer4 }),
+            _ => None,
         }
     }
 
@@ -657,9 +621,10 @@ impl Property {
             match self.property_type() {
                 PropertyType::Byte => Some(self.cprop.value.byte as i32),
                 PropertyType::TwoByteInteger => Some(self.cprop.value.integer2 as i32),
-                PropertyType::FourByteInteger | PropertyType::VariableByteInteger =>
-                    Some(self.cprop.value.integer4 as i32),
-                _ => None
+                PropertyType::FourByteInteger | PropertyType::VariableByteInteger => {
+                    Some(self.cprop.value.integer4 as i32)
+                }
+                _ => None,
             }
         }
     }
@@ -674,8 +639,7 @@ impl Property {
                 let vc = v.clone();
                 mem::forget(v);
                 Some(vc)
-            }
-            else {
+            } else {
                 None
             }
         }
@@ -689,15 +653,14 @@ impl Property {
                 let sc = s.clone();
                 s.into_raw();
                 sc.into_string().ok()
-            }
-            else {
+            } else {
                 None
             }
         }
     }
 
     /// Gets the property value as a string pair.
-    pub fn get_string_pair(&self) -> Option<(String,String)> {
+    pub fn get_string_pair(&self) -> Option<(String, String)> {
         unsafe {
             if self.property_type() == PropertyType::Utf8StringPair {
                 let s = CString::from_raw(self.cprop.value.__bindgen_anon_1.data.data);
@@ -710,8 +673,7 @@ impl Property {
                 s.into_raw();
                 let valopt = sc.into_string().ok();
                 keyopt.and_then(|key| valopt.map(|val| (key, val)))
-            }
-            else {
+            } else {
                 None
             }
         }
@@ -725,19 +687,29 @@ impl Drop for Property {
         unsafe {
             match self.property_type() {
                 PropertyType::BinaryData => {
-                    debug!("Dropping binary property: {:?}", self.cprop.value.__bindgen_anon_1.data.data);
+                    debug!(
+                        "Dropping binary property: {:?}",
+                        self.cprop.value.__bindgen_anon_1.data.data
+                    );
                     let n = self.cprop.value.__bindgen_anon_1.data.len as usize;
                     let _ = Vec::from_raw_parts(self.cprop.value.__bindgen_anon_1.data.data, n, n);
-                },
+                }
                 PropertyType::Utf8EncodedString => {
-                    debug!("Dropping string property: {:?}", self.cprop.value.__bindgen_anon_1.data.data);
+                    debug!(
+                        "Dropping string property: {:?}",
+                        self.cprop.value.__bindgen_anon_1.data.data
+                    );
                     let _ = CString::from_raw(self.cprop.value.__bindgen_anon_1.data.data);
-                },
+                }
                 PropertyType::Utf8StringPair => {
-                    debug!("Dropping string pair property: {:?}, {:?}", self.cprop.value.__bindgen_anon_1.data.data, self.cprop.value.__bindgen_anon_1.value.data);
+                    debug!(
+                        "Dropping string pair property: {:?}, {:?}",
+                        self.cprop.value.__bindgen_anon_1.data.data,
+                        self.cprop.value.__bindgen_anon_1.value.data
+                    );
                     let _ = CString::from_raw(self.cprop.value.__bindgen_anon_1.data.data);
                     let _ = CString::from_raw(self.cprop.value.__bindgen_anon_1.value.data);
-                },
+                }
                 _ => (),
             }
         }
@@ -762,13 +734,13 @@ impl Clone for Property {
                     cprop.value.__bindgen_anon_1.data.data = p;
                     mem::forget(v);
                     mem::forget(vc);
-                },
+                }
                 PropertyType::Utf8EncodedString => {
                     let s = CString::from_raw(cprop.value.__bindgen_anon_1.data.data);
                     let sc = s.clone();
                     s.into_raw();
                     cprop.value.__bindgen_anon_1.data.data = sc.into_raw();
-                },
+                }
                 PropertyType::Utf8StringPair => {
                     let s = CString::from_raw(cprop.value.__bindgen_anon_1.data.data);
                     let sc = s.clone();
@@ -779,11 +751,11 @@ impl Clone for Property {
                     let sc = s.clone();
                     cprop.value.__bindgen_anon_1.value.data = sc.into_raw();
                     s.into_raw();
-                },
+                }
                 _ => (),
             }
         }
-        Property { cprop, }
+        Property { cprop }
     }
 }
 
@@ -808,7 +780,7 @@ impl Properties {
     pub fn from_c_struct(cprops: &ffi::MQTTProperties) -> Self {
         // This does a deep copy in the C lib
         let cprops = unsafe { ffi::MQTTProperties_copy(cprops) };
-        Properties { cprops, }
+        Properties { cprops }
     }
 
     /// Determines if the property list has no items in it.
@@ -840,15 +812,15 @@ impl Properties {
         if rc == 0 {
             mem::forget(prop);
             Ok(())
-        }
-        else {
+        } else {
             Err(rc.into())
         }
     }
 
     /// Adds a property to the collection given the property code and value.
     pub fn push_val<T>(&mut self, code: PropertyCode, val: T) -> Result<()>
-        where T: Any + 'static
+    where
+        T: Any + 'static,
     {
         self.push(Property::new(code, val)?)
     }
@@ -877,7 +849,9 @@ impl Properties {
 
     /// Adds a binary property to the collection
     pub fn push_binary<V>(&mut self, code: PropertyCode, bin: V) -> Result<()>
-            where V: Into<Binary> {
+    where
+        V: Into<Binary>,
+    {
         self.push(Property::new_binary(code, bin)?)
     }
 
@@ -901,19 +875,28 @@ impl Properties {
         let ps = &self.cprops as *const _ as *mut ffi::MQTTProperties;
         unsafe {
             let p = ffi::MQTTProperties_getPropertyAt(ps, code as Code, idx as c_int);
-            if !p.is_null() { Property::from_c_property(&*p).ok() } else { None }
+            if !p.is_null() {
+                Property::from_c_property(&*p).ok()
+            } else {
+                None
+            }
         }
     }
 
     /// Gets an iterator for a property instance
     pub fn iter(&self, code: PropertyCode) -> PropertyIterator {
-        PropertyIterator { props: self, code, idx: 0 }
+        PropertyIterator {
+            props: self,
+            code,
+            idx: 0,
+        }
     }
 
     /// Gets a value from the collection when there may be more than one
     /// for the code.
     pub fn get_val_at<T>(&self, code: PropertyCode, idx: usize) -> Option<T>
-        where T: Any + 'static + Send + Default
+    where
+        T: Any + 'static + Send + Default,
     {
         self.get_at(code, idx).and_then(|prop| prop.get())
     }
@@ -921,7 +904,8 @@ impl Properties {
     /// Gets a value from the collection when there may be more than one
     /// for the code.
     pub fn get_val<T>(&self, code: PropertyCode) -> Option<T>
-        where T: Any + 'static + Send + Default
+    where
+        T: Any + 'static + Send + Default,
     {
         self.get_val_at(code, 0)
     }
@@ -957,25 +941,32 @@ impl Properties {
     }
 
     /// Gets a string pair for a specific property.
-    pub fn get_string_pair(&self, code: PropertyCode) -> Option<(String,String)> {
+    pub fn get_string_pair(&self, code: PropertyCode) -> Option<(String, String)> {
         self.get(code).and_then(|prop| prop.get_string_pair())
     }
 
     /// Gets a string pair for a specific property when there may be more than one.
-    pub fn get_string_pair_at(&self, code: PropertyCode, idx: usize) -> Option<(String,String)> {
-        self.get_at(code, idx).and_then(|prop| prop.get_string_pair())
+    pub fn get_string_pair_at(&self, code: PropertyCode, idx: usize) -> Option<(String, String)> {
+        self.get_at(code, idx)
+            .and_then(|prop| prop.get_string_pair())
     }
 
     /// Gets an iterator into the user property string pairs.
     pub fn user_iter(&self) -> StringPairIterator {
-        StringPairIterator { props: self, code: PropertyCode::UserProperty, idx: 0 }
+        StringPairIterator {
+            props: self,
+            code: PropertyCode::UserProperty,
+            idx: 0,
+        }
     }
 
     /// Searches for the specified key in the user properties and returns
     /// the value if found.
     pub fn find_user_property(&self, key: &str) -> Option<String> {
         for (k, v) in self.user_iter() {
-            if k == key { return Some(v); }
+            if k == key {
+                return Some(v);
+            }
         }
         None
     }
@@ -998,7 +989,7 @@ impl Clone for Properties {
     fn clone(&self) -> Self {
         // This does a deep copy in the C lib
         let cprops = unsafe { ffi::MQTTProperties_copy(&self.cprops) };
-        Properties { cprops, }
+        Properties { cprops }
     }
 }
 
@@ -1008,7 +999,6 @@ impl Drop for Properties {
         unsafe { ffi::MQTTProperties_free(&mut self.cprops) };
     }
 }
-
 
 /// Iterator over the values for a speciifc property
 pub struct PropertyIterator<'a> {
@@ -1027,7 +1017,6 @@ impl<'a> Iterator for PropertyIterator<'a> {
     }
 }
 
-
 /// Iterator over the values for a speciifc property
 pub struct StringPairIterator<'a> {
     props: &'a Properties,
@@ -1045,7 +1034,6 @@ impl<'a> Iterator for StringPairIterator<'a> {
     }
 }
 
-
 /////////////////////////////////////////////////////////////////////////////
 //                              Unit Tests
 /////////////////////////////////////////////////////////////////////////////
@@ -1057,22 +1045,32 @@ mod tests {
 
     #[test]
     fn test_property_type_new() {
-        assert_eq!(PropertyType::new(ffi::MQTTPropertyTypes_MQTTPROPERTY_TYPE_BYTE),
-                   Some(PropertyType::Byte));
-        assert_eq!(PropertyType::new(ffi::MQTTPropertyTypes_MQTTPROPERTY_TYPE_BINARY_DATA),
-                   Some(PropertyType::BinaryData));
+        assert_eq!(
+            PropertyType::new(ffi::MQTTPropertyTypes_MQTTPROPERTY_TYPE_BYTE),
+            Some(PropertyType::Byte)
+        );
+        assert_eq!(
+            PropertyType::new(ffi::MQTTPropertyTypes_MQTTPROPERTY_TYPE_BINARY_DATA),
+            Some(PropertyType::BinaryData)
+        );
 
         assert_eq!(PropertyType::new(7), None);
     }
 
     #[test]
     fn test_property_code_new() {
-        assert_eq!(PropertyCode::new(ffi::MQTTPropertyCodes_MQTTPROPERTY_CODE_PAYLOAD_FORMAT_INDICATOR),
-                   Some(PropertyCode::PayloadFormatIndicator));
-        assert_eq!(PropertyCode::new(ffi::MQTTPropertyCodes_MQTTPROPERTY_CODE_AUTHENTICATION_METHOD),
-                   Some(PropertyCode::AuthenticationMethod));
-        assert_eq!(PropertyCode::new(ffi::MQTTPropertyCodes_MQTTPROPERTY_CODE_USER_PROPERTY),
-                   Some(PropertyCode::UserProperty));
+        assert_eq!(
+            PropertyCode::new(ffi::MQTTPropertyCodes_MQTTPROPERTY_CODE_PAYLOAD_FORMAT_INDICATOR),
+            Some(PropertyCode::PayloadFormatIndicator)
+        );
+        assert_eq!(
+            PropertyCode::new(ffi::MQTTPropertyCodes_MQTTPROPERTY_CODE_AUTHENTICATION_METHOD),
+            Some(PropertyCode::AuthenticationMethod)
+        );
+        assert_eq!(
+            PropertyCode::new(ffi::MQTTPropertyCodes_MQTTPROPERTY_CODE_USER_PROPERTY),
+            Some(PropertyCode::UserProperty)
+        );
     }
 
     #[test]
@@ -1102,7 +1100,10 @@ mod tests {
         let prop = Property::new_byte(PropertyCode::PayloadFormatIndicator, val).unwrap();
 
         unsafe {
-            assert_eq!(prop.cprop.identifier, PropertyCode::PayloadFormatIndicator as Code);
+            assert_eq!(
+                prop.cprop.identifier,
+                PropertyCode::PayloadFormatIndicator as Code
+            );
             assert_eq!(prop.cprop.value.byte, val);
         }
 
@@ -1113,7 +1114,10 @@ mod tests {
         let prop = Property::new_int(PropertyCode::PayloadFormatIndicator, val).unwrap();
 
         unsafe {
-            assert_eq!(prop.cprop.identifier, PropertyCode::PayloadFormatIndicator as Code);
+            assert_eq!(
+                prop.cprop.identifier,
+                PropertyCode::PayloadFormatIndicator as Code
+            );
             assert_eq!(prop.cprop.value.byte, val as u8);
         }
 
@@ -1157,18 +1161,21 @@ mod tests {
 
     #[test]
     fn test_new_property_i32() {
-        let val = 1024*1024;
+        let val = 1024 * 1024;
         let prop = Property::new_int(PropertyCode::MessageExpiryInterval, val).unwrap();
 
         unsafe {
-            assert_eq!(prop.cprop.identifier, PropertyCode::MessageExpiryInterval as Code);
+            assert_eq!(
+                prop.cprop.identifier,
+                PropertyCode::MessageExpiryInterval as Code
+            );
             assert_eq!(prop.cprop.value.integer4, val as u32);
         }
     }
 
     #[test]
     fn test_new_property_binary() {
-        let val = "12345";  // Anything that can be converted into Vec<u8>
+        let val = "12345"; // Anything that can be converted into Vec<u8>
         let prop = Property::new_binary(PropertyCode::CorrelationData, val).unwrap();
 
         // We should have non-null data pointer, null value pointer
@@ -1191,7 +1198,10 @@ mod tests {
         // We should have non-null data pointer, null value pointer
         unsafe {
             assert!(!prop.cprop.value.__bindgen_anon_1.data.data.is_null());
-            assert_eq!(prop.cprop.value.__bindgen_anon_1.data.len, val.len() as c_int);
+            assert_eq!(
+                prop.cprop.value.__bindgen_anon_1.data.len,
+                val.len() as c_int
+            );
 
             let s = CStr::from_ptr(prop.cprop.value.__bindgen_anon_1.data.data);
             assert_eq!(val, s.to_str().unwrap());
@@ -1213,42 +1223,60 @@ mod tests {
         // We should have non-null data and value pointers
         unsafe {
             assert!(!prop.cprop.value.__bindgen_anon_1.data.data.is_null());
-            assert_eq!(prop.cprop.value.__bindgen_anon_1.data.len, key.len() as c_int);
+            assert_eq!(
+                prop.cprop.value.__bindgen_anon_1.data.len,
+                key.len() as c_int
+            );
 
             let s = CStr::from_ptr(prop.cprop.value.__bindgen_anon_1.data.data);
             assert_eq!(key, s.to_str().unwrap());
 
             assert!(!prop.cprop.value.__bindgen_anon_1.value.data.is_null());
-            assert_eq!(prop.cprop.value.__bindgen_anon_1.value.len, val.len() as c_int);
+            assert_eq!(
+                prop.cprop.value.__bindgen_anon_1.value.len,
+                val.len() as c_int
+            );
 
             let s = CStr::from_ptr(prop.cprop.value.__bindgen_anon_1.value.data);
             assert_eq!(val, s.to_str().unwrap());
         }
 
-        assert_eq!(prop.get_string_pair(), Some((key.to_string(), val.to_string())));
-        assert_eq!(prop.get::<(String,String)>(), Some((key.to_string(), val.to_string())));
+        assert_eq!(
+            prop.get_string_pair(),
+            Some((key.to_string(), val.to_string()))
+        );
+        assert_eq!(
+            prop.get::<(String, String)>(),
+            Some((key.to_string(), val.to_string()))
+        );
     }
 
     #[test]
     fn test_move_property_int() {
-        let val = 1024*1024;
+        let val = 1024 * 1024;
 
         let org_prop = Property::new_int(PropertyCode::MessageExpiryInterval, val).unwrap();
         unsafe {
-            assert_eq!(org_prop.cprop.identifier, PropertyCode::MessageExpiryInterval as Code);
+            assert_eq!(
+                org_prop.cprop.identifier,
+                PropertyCode::MessageExpiryInterval as Code
+            );
             assert_eq!(org_prop.cprop.value.integer4, val as u32);
         }
 
         let prop = org_prop;
         unsafe {
-            assert_eq!(prop.cprop.identifier, PropertyCode::MessageExpiryInterval as Code);
+            assert_eq!(
+                prop.cprop.identifier,
+                PropertyCode::MessageExpiryInterval as Code
+            );
             assert_eq!(prop.cprop.value.integer4, val as u32);
         }
     }
 
     #[test]
     fn test_move_property_binary() {
-        let val = "12345";  // Anything that can be converted into Vec<u8>
+        let val = "12345"; // Anything that can be converted into Vec<u8>
         let org_prop = Property::new_binary(PropertyCode::CorrelationData, val).unwrap();
 
         let prop = org_prop;
@@ -1276,7 +1304,10 @@ mod tests {
             assert_eq!(prop.cprop.identifier, PropertyCode::ResponseTopic as Code);
 
             assert!(!prop.cprop.value.__bindgen_anon_1.data.data.is_null());
-            assert_eq!(prop.cprop.value.__bindgen_anon_1.data.len, val.len() as c_int);
+            assert_eq!(
+                prop.cprop.value.__bindgen_anon_1.data.len,
+                val.len() as c_int
+            );
 
             assert!(prop.cprop.value.__bindgen_anon_1.value.data.is_null());
             assert_eq!(prop.cprop.value.__bindgen_anon_1.value.len, 0);
@@ -1285,7 +1316,7 @@ mod tests {
 
     #[test]
     fn test_clone_property_binary() {
-        let val = "12345";  // Anything that can be converted into Vec<u8>
+        let val = "12345"; // Anything that can be converted into Vec<u8>
         let org_prop = Property::new_binary(PropertyCode::CorrelationData, val).unwrap();
 
         let prop = org_prop.clone();
@@ -1300,9 +1331,10 @@ mod tests {
             assert!(prop.cprop.value.__bindgen_anon_1.value.data.is_null());
             assert_eq!(prop.cprop.value.__bindgen_anon_1.value.len, 0);
 
-            assert_ne!(org_prop.cprop.value.__bindgen_anon_1.data.data,
-                       prop.cprop.value.__bindgen_anon_1.data.data);
-
+            assert_ne!(
+                org_prop.cprop.value.__bindgen_anon_1.data.data,
+                prop.cprop.value.__bindgen_anon_1.data.data
+            );
         }
     }
 
@@ -1317,7 +1349,10 @@ mod tests {
             assert_eq!(prop.cprop.identifier, PropertyCode::ResponseTopic as Code);
 
             assert!(!prop.cprop.value.__bindgen_anon_1.data.data.is_null());
-            assert_eq!(prop.cprop.value.__bindgen_anon_1.data.len, val.len() as c_int);
+            assert_eq!(
+                prop.cprop.value.__bindgen_anon_1.data.len,
+                val.len() as c_int
+            );
 
             assert!(prop.cprop.value.__bindgen_anon_1.value.data.is_null());
             assert_eq!(prop.cprop.value.__bindgen_anon_1.value.len, 0);
@@ -1350,17 +1385,20 @@ mod tests {
         assert!(!props.is_empty());
     }
 
-
     #[test]
     fn test_properties_push_val() {
         let mut props = Properties::new();
 
-        props.push_val(PropertyCode::ResponseTopic, "responses/somewhere").unwrap();
+        props
+            .push_val(PropertyCode::ResponseTopic, "responses/somewhere")
+            .unwrap();
 
         assert!(!props.is_empty());
         assert_eq!(props.len(), 1);
 
-        props.push_val(PropertyCode::CorrelationData, b"12345").unwrap();
+        props
+            .push_val(PropertyCode::CorrelationData, b"12345")
+            .unwrap();
         assert_eq!(props.len(), 2);
     }
 
@@ -1386,26 +1424,44 @@ mod tests {
 
         let mut props = Properties::new();
 
-        props.push(Property::new_string_pair(code, "user0", "val0").unwrap()).unwrap();
-        props.push(Property::new_string_pair(code, "user1", "val1").unwrap()).unwrap();
-        props.push(Property::new_string_pair(code, "user2", "val2").unwrap()).unwrap();
+        props
+            .push(Property::new_string_pair(code, "user0", "val0").unwrap())
+            .unwrap();
+        props
+            .push(Property::new_string_pair(code, "user1", "val1").unwrap())
+            .unwrap();
+        props
+            .push(Property::new_string_pair(code, "user2", "val2").unwrap())
+            .unwrap();
 
         assert!(!props.is_empty());
         assert_eq!(props.len(), 3);
 
-        assert_eq!(props.get_string_pair_at(code, 0).unwrap(),
-                   ("user0".to_string(), "val0".to_string()));
-        assert_eq!(props.get_string_pair_at(code, 1).unwrap(),
-                   ("user1".to_string(), "val1".to_string()));
-        assert_eq!(props.get_string_pair_at(code, 2).unwrap(),
-                   ("user2".to_string(), "val2".to_string()));
+        assert_eq!(
+            props.get_string_pair_at(code, 0).unwrap(),
+            ("user0".to_string(), "val0".to_string())
+        );
+        assert_eq!(
+            props.get_string_pair_at(code, 1).unwrap(),
+            ("user1".to_string(), "val1".to_string())
+        );
+        assert_eq!(
+            props.get_string_pair_at(code, 2).unwrap(),
+            ("user2".to_string(), "val2".to_string())
+        );
 
-        assert_eq!(props.get_val::<(String,String)>(code),
-                   Some(("user0".to_string(), "val0".to_string())));
-        assert_eq!(props.get_val_at::<(String,String)>(code, 1),
-                   Some(("user1".to_string(), "val1".to_string())));
-        assert_eq!(props.get_val_at::<(String,String)>(code, 2),
-                   Some(("user2".to_string(), "val2".to_string())));
+        assert_eq!(
+            props.get_val::<(String, String)>(code),
+            Some(("user0".to_string(), "val0".to_string()))
+        );
+        assert_eq!(
+            props.get_val_at::<(String, String)>(code, 1),
+            Some(("user1".to_string(), "val1".to_string()))
+        );
+        assert_eq!(
+            props.get_val_at::<(String, String)>(code, 2),
+            Some(("user2".to_string(), "val2".to_string()))
+        );
 
         assert_eq!(props.get_string_pair_at(code, 3), None);
     }
@@ -1422,12 +1478,18 @@ mod tests {
 
         let mut it = props.iter(code);
 
-        assert_eq!(it.next().and_then(|prop| prop.get_string_pair()),
-                   Some(("user0".to_string(), "val0".to_string())));
-        assert_eq!(it.next().and_then(|prop| prop.get_string_pair()),
-                   Some(("user1".to_string(), "val1".to_string())));
-        assert_eq!(it.next().and_then(|prop| prop.get_string_pair()),
-                   Some(("user2".to_string(), "val2".to_string())));
+        assert_eq!(
+            it.next().and_then(|prop| prop.get_string_pair()),
+            Some(("user0".to_string(), "val0".to_string()))
+        );
+        assert_eq!(
+            it.next().and_then(|prop| prop.get_string_pair()),
+            Some(("user1".to_string(), "val1".to_string()))
+        );
+        assert_eq!(
+            it.next().and_then(|prop| prop.get_string_pair()),
+            Some(("user2".to_string(), "val2".to_string()))
+        );
 
         assert_eq!(it.next().and_then(|prop| prop.get_string_pair()), None);
     }
@@ -1444,12 +1506,9 @@ mod tests {
 
         let mut it = props.user_iter();
 
-        assert_eq!(it.next(),
-                   Some(("user0".to_string(), "val0".to_string())));
-        assert_eq!(it.next(),
-                   Some(("user1".to_string(), "val1".to_string())));
-        assert_eq!(it.next(),
-                   Some(("user2".to_string(), "val2".to_string())));
+        assert_eq!(it.next(), Some(("user0".to_string(), "val0".to_string())));
+        assert_eq!(it.next(), Some(("user1".to_string(), "val1".to_string())));
+        assert_eq!(it.next(), Some(("user2".to_string(), "val2".to_string())));
 
         assert_eq!(it.next(), None);
     }
@@ -1460,9 +1519,15 @@ mod tests {
 
         let mut props = Properties::new();
 
-        props.push(Property::new_string_pair(code, "user0", "val0").unwrap()).unwrap();
-        props.push(Property::new_string_pair(code, "user1", "val1").unwrap()).unwrap();
-        props.push(Property::new_string_pair(code, "user2", "val2").unwrap()).unwrap();
+        props
+            .push(Property::new_string_pair(code, "user0", "val0").unwrap())
+            .unwrap();
+        props
+            .push(Property::new_string_pair(code, "user1", "val1").unwrap())
+            .unwrap();
+        props
+            .push(Property::new_string_pair(code, "user2", "val2").unwrap())
+            .unwrap();
 
         assert_eq!(props.find_user_property("user0"), Some("val0".to_string()));
         assert_eq!(props.find_user_property("user1"), Some("val1".to_string()));
@@ -1472,13 +1537,12 @@ mod tests {
 
     #[test]
     fn test_properties_macro() {
-
         // Zero length
         let props = properties![];
         assert!(props.is_empty());
 
         // Some different properties
-        let props = properties!{
+        let props = properties! {
             PropertyCode::ResponseTopic => "responses/somewhere",
             PropertyCode::CorrelationData => b"12345",
             PropertyCode::MaximumQos => 1,
@@ -1487,14 +1551,19 @@ mod tests {
         println!("{:?}", props);
         assert!(!props.is_empty());
         assert_eq!(3, props.len());
-        assert_eq!(Some(b"12345".to_vec()), props.get_val::<Vec<u8>>(PropertyCode::CorrelationData));
+        assert_eq!(
+            Some(b"12345".to_vec()),
+            props.get_val::<Vec<u8>>(PropertyCode::CorrelationData)
+        );
 
-        let props = properties!{
+        let props = properties! {
             PropertyCode::SessionExpiryInterval => 60,
         };
 
         assert_eq!(1, props.len());
-        assert_eq!(Some(60), props.get_val::<i32>(PropertyCode::SessionExpiryInterval));
+        assert_eq!(
+            Some(60),
+            props.get_val::<i32>(PropertyCode::SessionExpiryInterval)
+        );
     }
 }
-

--- a/src/reason_code.rs
+++ b/src/reason_code.rs
@@ -21,17 +21,14 @@
 
 //! The Reason Code module for the Paho MQTT Rust client library.
 
-use std::{
-    fmt,
-    ffi::CStr,
-};
 use ffi;
+use std::{ffi::CStr, fmt};
 
 /// MQTT v5 single-byte reason codes.
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum ReasonCode {
-    Success = 0,          // also: NormalDisconnection & GrantedQos0
+    Success = 0, // also: NormalDisconnection & GrantedQos0
     GrantedQos1 = 1,
     GrantedQos2 = 2,
     DisconnectWithWillMessage = 4,
@@ -75,7 +72,7 @@ pub enum ReasonCode {
     MaximumConnectTime = 160,
     SubscriptionIdentifiersNotSupported = 161,
     WildcardSubscriptionsNotSupported = 162,
-	MqttppV3Code = 255             // This is not a protocol code; used internally by the library
+    MqttppV3Code = 255, // This is not a protocol code; used internally by the library
 }
 
 // Some aliased ReasonCode values
@@ -96,16 +93,18 @@ impl ReasonCode {
 }
 
 impl Default for ReasonCode {
-    fn default() -> Self { ReasonCode::Success }
+    fn default() -> Self {
+        ReasonCode::Success
+    }
 }
 
 impl From<ffi::MQTTReasonCodes> for ReasonCode {
     fn from(code: ffi::MQTTReasonCodes) -> Self {
         match code {
-             0 => ReasonCode::Success,          // also: NormalDisconnection & GrantedQos0
-             1 => ReasonCode::GrantedQos1,
-             2 => ReasonCode::GrantedQos2,
-             4 => ReasonCode::DisconnectWithWillMessage,
+            0 => ReasonCode::Success, // also: NormalDisconnection & GrantedQos0
+            1 => ReasonCode::GrantedQos1,
+            2 => ReasonCode::GrantedQos2,
+            4 => ReasonCode::DisconnectWithWillMessage,
             16 => ReasonCode::NoMatchingSubscribers,
             17 => ReasonCode::NoSubscriptionFound,
             24 => ReasonCode::ContinueAuthentication,
@@ -146,7 +145,7 @@ impl From<ffi::MQTTReasonCodes> for ReasonCode {
             160 => ReasonCode::MaximumConnectTime,
             161 => ReasonCode::SubscriptionIdentifiersNotSupported,
             162 => ReasonCode::WildcardSubscriptionsNotSupported,
-            _ => ReasonCode::MqttppV3Code             // This is not a protocol code; used internally by the library
+            _ => ReasonCode::MqttppV3Code, // This is not a protocol code; used internally by the library
         }
     }
 }
@@ -158,15 +157,13 @@ impl fmt::Display for ReasonCode {
 
             if p.is_null() {
                 write!(f, "Unknown")
-            }
-            else {
+            } else {
                 let s = CStr::from_ptr(p).to_string_lossy();
                 write!(f, "{}", s)
             }
         }
     }
 }
-
 
 /////////////////////////////////////////////////////////////////////////////
 //                              Unit Tests
@@ -178,32 +175,48 @@ mod tests {
 
     #[test]
     fn test_as() {
-        assert_eq!(ReasonCode::Success as ffi::MQTTReasonCodes,
-                   ffi::MQTTReasonCodes_MQTTREASONCODE_SUCCESS);
+        assert_eq!(
+            ReasonCode::Success as ffi::MQTTReasonCodes,
+            ffi::MQTTReasonCodes_MQTTREASONCODE_SUCCESS
+        );
 
-        assert_eq!(ReasonCode::DisconnectWithWillMessage as ffi::MQTTReasonCodes,
-                   ffi::MQTTReasonCodes_MQTTREASONCODE_DISCONNECT_WITH_WILL_MESSAGE);
+        assert_eq!(
+            ReasonCode::DisconnectWithWillMessage as ffi::MQTTReasonCodes,
+            ffi::MQTTReasonCodes_MQTTREASONCODE_DISCONNECT_WITH_WILL_MESSAGE
+        );
 
-        assert_eq!(ReasonCode::UnspecifiedError as ffi::MQTTReasonCodes,
-                   ffi::MQTTReasonCodes_MQTTREASONCODE_UNSPECIFIED_ERROR);
+        assert_eq!(
+            ReasonCode::UnspecifiedError as ffi::MQTTReasonCodes,
+            ffi::MQTTReasonCodes_MQTTREASONCODE_UNSPECIFIED_ERROR
+        );
 
-        assert_eq!(ReasonCode::MaximumConnectTime as ffi::MQTTReasonCodes,
-                   ffi::MQTTReasonCodes_MQTTREASONCODE_MAXIMUM_CONNECT_TIME);
+        assert_eq!(
+            ReasonCode::MaximumConnectTime as ffi::MQTTReasonCodes,
+            ffi::MQTTReasonCodes_MQTTREASONCODE_MAXIMUM_CONNECT_TIME
+        );
     }
 
     #[test]
     fn test_from() {
-        assert_eq!(ReasonCode::Success,
-                   ReasonCode::from(ffi::MQTTReasonCodes_MQTTREASONCODE_SUCCESS));
+        assert_eq!(
+            ReasonCode::Success,
+            ReasonCode::from(ffi::MQTTReasonCodes_MQTTREASONCODE_SUCCESS)
+        );
 
-        assert_eq!(ReasonCode::DisconnectWithWillMessage,
-                   ReasonCode::from(ffi::MQTTReasonCodes_MQTTREASONCODE_DISCONNECT_WITH_WILL_MESSAGE));
+        assert_eq!(
+            ReasonCode::DisconnectWithWillMessage,
+            ReasonCode::from(ffi::MQTTReasonCodes_MQTTREASONCODE_DISCONNECT_WITH_WILL_MESSAGE)
+        );
 
-        assert_eq!(ReasonCode::UnspecifiedError,
-                   ReasonCode::from(ffi::MQTTReasonCodes_MQTTREASONCODE_UNSPECIFIED_ERROR));
+        assert_eq!(
+            ReasonCode::UnspecifiedError,
+            ReasonCode::from(ffi::MQTTReasonCodes_MQTTREASONCODE_UNSPECIFIED_ERROR)
+        );
 
-        assert_eq!(ReasonCode::MaximumConnectTime,
-                   ReasonCode::from(ffi::MQTTReasonCodes_MQTTREASONCODE_MAXIMUM_CONNECT_TIME));
+        assert_eq!(
+            ReasonCode::MaximumConnectTime,
+            ReasonCode::from(ffi::MQTTReasonCodes_MQTTREASONCODE_MAXIMUM_CONNECT_TIME)
+        );
     }
 
     #[test]

--- a/src/server_response.rs
+++ b/src/server_response.rs
@@ -33,12 +33,7 @@
 
 use std::ffi::CStr;
 
-use crate::{
-    ffi,
-    from_c_bool,
-    properties::Properties,
-    reason_code::ReasonCode,
-};
+use crate::{ffi, from_c_bool, properties::Properties, reason_code::ReasonCode};
 
 /////////////////////////////////////////////////////////////////////////////
 // ServerRequest
@@ -63,7 +58,9 @@ pub enum ServerRequest {
 }
 
 impl Default for ServerRequest {
-    fn default() -> Self { ServerRequest::None }
+    fn default() -> Self {
+        ServerRequest::None
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -88,7 +85,9 @@ pub enum RequestResponse {
 }
 
 impl Default for RequestResponse {
-    fn default() -> Self { RequestResponse::None }
+    fn default() -> Self {
+        RequestResponse::None
+    }
 }
 
 /// The response from the server on a connect request.
@@ -118,7 +117,9 @@ pub struct ServerResponse {
 
 impl ServerResponse {
     /// Creates a new, empty, server response.
-    pub fn new() -> Self { ServerResponse::default() }
+    pub fn new() -> Self {
+        ServerResponse::default()
+    }
 
     /// Creates the response object from the v3 "success" data structure
     /// sent by the C lib on completion of the operation.
@@ -126,26 +127,27 @@ impl ServerResponse {
         let rsp = match req {
             ServerRequest::Connect => {
                 let conn_rsp = ConnectResponse {
-                    server_uri: CStr::from_ptr(rsp.alt.connect.serverURI).to_string_lossy().to_string(),
+                    server_uri: CStr::from_ptr(rsp.alt.connect.serverURI)
+                        .to_string_lossy()
+                        .to_string(),
                     mqtt_version: rsp.alt.connect.MQTTVersion,
                     session_present: from_c_bool(rsp.alt.connect.sessionPresent),
                 };
                 RequestResponse::Connect(conn_rsp)
-            },
+            }
             ServerRequest::Subscribe => RequestResponse::Subscribe(rsp.alt.qos),
             ServerRequest::SubscribeMany(n) => {
                 let mut qosv = Vec::new();
                 if n == 1 {
                     qosv.push(rsp.alt.qos);
-                }
-                else if !rsp.alt.qosList.is_null() {
+                } else if !rsp.alt.qosList.is_null() {
                     for i in 0..n {
                         qosv.push(*rsp.alt.qosList.offset(i as isize));
                     }
                 }
                 debug!("Subscribed to {} topics w/ QoS: {:?}", qosv.len(), qosv);
                 RequestResponse::SubscribeMany(qosv)
-            },
+            }
             _ => RequestResponse::None,
         };
         ServerResponse {
@@ -165,12 +167,14 @@ impl ServerResponse {
         let rsp = match req {
             ServerRequest::Connect => {
                 let conn_rsp = ConnectResponse {
-                    server_uri: CStr::from_ptr(rsp.alt.connect.serverURI).to_string_lossy().to_string(),
+                    server_uri: CStr::from_ptr(rsp.alt.connect.serverURI)
+                        .to_string_lossy()
+                        .to_string(),
                     mqtt_version: rsp.alt.connect.MQTTVersion,
                     session_present: from_c_bool(rsp.alt.connect.sessionPresent),
                 };
                 RequestResponse::Connect(conn_rsp)
-            },
+            }
             ServerRequest::Subscribe => RequestResponse::Subscribe(rsp.reasonCode as i32),
             ServerRequest::SubscribeMany(n) => {
                 let ncode = rsp.alt.sub.reasonCodeCount as usize;
@@ -180,15 +184,14 @@ impl ServerResponse {
                 let mut qosv = Vec::new();
                 if n == 1 {
                     qosv.push(rsp.reasonCode as i32);
-                }
-                else if !rsp.alt.sub.reasonCodes.is_null() {
+                } else if !rsp.alt.sub.reasonCodes.is_null() {
                     for i in 0..n {
                         qosv.push(rsp.alt.sub.reasonCodes.offset(i as isize) as i32);
                     }
                 }
                 debug!("Subscribed to {} topics w/ QoS: {:?}", qosv.len(), qosv);
                 RequestResponse::SubscribeMany(qosv)
-            },
+            }
             ServerRequest::Unsubscribe => RequestResponse::Unsubscribe(rsp.reasonCode as i32),
             ServerRequest::UnsubscribeMany(n) => {
                 let ncode = rsp.alt.unsub.reasonCodeCount as usize;
@@ -199,15 +202,14 @@ impl ServerResponse {
                 let mut qosv = Vec::new();
                 if n == 1 {
                     qosv.push(rsp.reasonCode as i32);
-                }
-                else if !rsp.alt.sub.reasonCodes.is_null() {
+                } else if !rsp.alt.sub.reasonCodes.is_null() {
                     for i in 0..n {
                         qosv.push(rsp.alt.unsub.reasonCodes.offset(i as isize) as i32);
                     }
                 }
                 debug!("Subscribed to {} topics w/ Qos: {:?}", qosv.len(), qosv);
                 RequestResponse::SubscribeMany(qosv)
-            },
+            }
             _ => RequestResponse::None,
         };
         ServerResponse {
@@ -235,8 +237,7 @@ impl ServerResponse {
     /// Gets the response for a connection request
     pub fn connect_response(&self) -> Option<ConnectResponse> {
         match &self.rsp {
-            RequestResponse::Connect(conn_rsp) =>
-                Some(conn_rsp.clone()),
+            RequestResponse::Connect(conn_rsp) => Some(conn_rsp.clone()),
             _ => None,
         }
     }
@@ -283,4 +284,3 @@ impl ServerResponse {
         self.reason_code
     }
 }
-

--- a/src/string_collection.rs
+++ b/src/string_collection.rs
@@ -1,8 +1,8 @@
 // string_collection.rs
-// 
+//
 // This file is part of the Eclipse Paho MQTT Rust Client library.
 //
-// A string_collection is a helper to bridge between a collection of 
+// A string_collection is a helper to bridge between a collection of
 // strings in Rust to an array of NUL terminated char string pointers
 // that  the C library expects.
 //
@@ -25,18 +25,13 @@
  *    Frank Pagliughi - initial implementation and documentation
  *******************************************************************************/
 
-use std::{
-    ffi::CString,
-    os::raw::c_char,
-    pin::Pin,
-};
+use std::{ffi::CString, os::raw::c_char, pin::Pin};
 
 /// A collection of C-compatible (NUL-terminated) strings that is useful
 /// with C API's that require an array of strings, normally specified as:
 /// `const char* arr[]` or  `const char** arr`
 #[derive(Debug)]
-pub struct StringCollection
-{
+pub struct StringCollection {
     /// A vector cache of pointers into the data `coll`
     /// This must be updated any time the data is modified.
     c_coll: Vec<*const c_char>,
@@ -53,8 +48,7 @@ struct StringCollectionData {
     coll: Vec<CString>,
 }
 
-impl StringCollection
-{
+impl StringCollection {
     /// Creates a StringCollection from a vector of string references.
     ///
     /// # Arguments
@@ -62,7 +56,8 @@ impl StringCollection
     /// `coll` A collection of string references.
     ///
     pub fn new<T>(coll: &[T]) -> Self
-        where T: AsRef<str>
+    where
+        T: AsRef<str>,
     {
         let data = StringCollectionData {
             coll: Self::to_cstring(coll),
@@ -72,7 +67,8 @@ impl StringCollection
 
     // Convert a collection of string references to a vector of CStrings.
     fn to_cstring<T>(coll: &[T]) -> Vec<CString>
-        where T: AsRef<str>
+    where
+        T: AsRef<str>,
     {
         coll.iter()
             .map(|s| CString::new(s.as_ref()).unwrap())
@@ -100,11 +96,17 @@ impl StringCollection
         let data = Box::pin(data);
         let c_coll = Self::to_c_vec(&data.coll);
         let c_mut_coll = Self::to_c_mut_vec(&data.coll);
-        Self { c_coll, c_mut_coll, data }
+        Self {
+            c_coll,
+            c_mut_coll,
+            data,
+        }
     }
 
     /// Gets the number of strings in the collection.
-    pub fn len(&self) -> usize { self.data.coll.len() }
+    pub fn len(&self) -> usize {
+        self.data.coll.len()
+    }
 
     /// Gets the collection as a pointer to const C string pointers.
     ///
@@ -133,15 +135,13 @@ impl StringCollection
     }
 }
 
-impl Default for StringCollection
-{
+impl Default for StringCollection {
     fn default() -> Self {
         Self::from_data(StringCollectionData::default())
     }
 }
 
-impl Clone for StringCollection
-{
+impl Clone for StringCollection {
     fn clone(&self) -> Self {
         Self::from_data((&*self.data).clone())
     }
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_new_from_vec_strings() {
-        let v = vec_of_strings![ "string0", "string1", "string2" ];
+        let v = vec_of_strings!["string0", "string1", "string2"];
         let n = v.len();
 
         let sc = StringCollection::new(&v);
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_assign() {
-        let v = [ "string0", "string1", "string2" ];
+        let v = ["string0", "string1", "string2"];
         let n = v.len();
 
         let org_sc = StringCollection::new(&v);
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_clone() {
-        let v = [ "string0", "string1", "string2" ];
+        let v = ["string0", "string1", "string2"];
         let n = v.len();
 
         let sc = {
@@ -254,4 +254,3 @@ mod tests {
         assert_eq!(sc.data.coll[2].as_ptr(), sc.c_coll[2]);
     }
 }
-

--- a/src/subscribe_options.rs
+++ b/src/subscribe_options.rs
@@ -24,11 +24,8 @@
 //! These are defined in section 3.8.3.1 of the MQTT v5 spec.
 //! The defaults use the behavior that was present in MQTT v3.1.1.
 
+use crate::{ffi, to_c_bool};
 use std::fmt;
-use crate::{
-    ffi,
-    to_c_bool,
-};
 
 /// Don't receive our own publications when subscribed to the same topics.
 pub const SUBSCRIBE_NO_LOCAL: bool = true;
@@ -45,12 +42,12 @@ pub const RETAIN_AS_PUBLISHED: bool = true;
 #[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum RetainHandling {
-	/// Send retained messages at the time of the subscribe
-	SendRetainedOnSubscribe = 0,
-	/// Send retained messages on subscribe only if subscription is new
-	SendRetainedOnNew = 1,
-	/// Do not send retained messages at all
-	DontSendRetained = 2
+    /// Send retained messages at the time of the subscribe
+    SendRetainedOnSubscribe = 0,
+    /// Send retained messages on subscribe only if subscription is new
+    SendRetainedOnNew = 1,
+    /// Do not send retained messages at all
+    DontSendRetained = 2,
 }
 
 impl Default for RetainHandling {
@@ -62,12 +59,9 @@ impl Default for RetainHandling {
 impl fmt::Display for RetainHandling {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            RetainHandling::SendRetainedOnSubscribe =>
-                write!(f, "Send Retain on Subscribe"),
-            RetainHandling::SendRetainedOnNew =>
-                write!(f, "Send Retain on New"),
-            RetainHandling::DontSendRetained =>
-                write!(f, "Don't Send Retain"),
+            RetainHandling::SendRetainedOnSubscribe => write!(f, "Send Retain on Subscribe"),
+            RetainHandling::SendRetainedOnNew => write!(f, "Send Retain on New"),
+            RetainHandling::DontSendRetained => write!(f, "Don't Send Retain"),
         }
     }
 }
@@ -85,31 +79,33 @@ impl SubscribeOptions {
             copts: ffi::MQTTSubscribe_options {
                 noLocal: to_c_bool(no_local) as u8,
                 ..ffi::MQTTSubscribe_options::default()
-            }
+            },
         }
     }
 }
 
 impl From<bool> for SubscribeOptions {
-	fn from(no_local: bool) -> Self {
-		SubscribeOptions::new(no_local)
-	}
+    fn from(no_local: bool) -> Self {
+        SubscribeOptions::new(no_local)
+    }
 }
 
-impl From<(bool,bool)> for SubscribeOptions {
-	fn from((no_local, retain_as_published): (bool, bool)) -> Self {
-		let mut opts = SubscribeOptions::new(no_local);
-		opts.copts.retainAsPublished = to_c_bool(retain_as_published) as u8;
-		opts
-	}
+impl From<(bool, bool)> for SubscribeOptions {
+    fn from((no_local, retain_as_published): (bool, bool)) -> Self {
+        let mut opts = SubscribeOptions::new(no_local);
+        opts.copts.retainAsPublished = to_c_bool(retain_as_published) as u8;
+        opts
+    }
 }
 
-impl From<(bool,bool,RetainHandling)> for SubscribeOptions {
-	fn from((no_local, retain_as_published, retain_handling): (bool, bool, RetainHandling)) -> Self {
+impl From<(bool, bool, RetainHandling)> for SubscribeOptions {
+    fn from(
+        (no_local, retain_as_published, retain_handling): (bool, bool, RetainHandling),
+    ) -> Self {
         let mut opts = SubscribeOptions::from((no_local, retain_as_published));
         opts.copts.retainHandling = retain_handling as u8;
-		opts
-	}
+        opts
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -152,7 +148,9 @@ impl SubscribeOptionsBuilder {
 
     /// Finalizes the builder to create the subscribe options.
     pub fn finalize(&self) -> SubscribeOptions {
-        SubscribeOptions { copts: self.copts.clone(), }
+        SubscribeOptions {
+            copts: self.copts.clone(),
+        }
     }
 }
 
@@ -203,9 +201,7 @@ mod tests {
 
     #[test]
     fn test_from_tuple_three() {
-        let opts = SubscribeOptions::from(
-            (true, true, RetainHandling::SendRetainedOnNew)
-        );
+        let opts = SubscribeOptions::from((true, true, RetainHandling::SendRetainedOnNew));
         assert!(opts.copts.noLocal != 0);
         assert!(opts.copts.retainAsPublished != 0);
         assert!(opts.copts.retainHandling == 1);
@@ -221,9 +217,7 @@ mod tests {
 
     #[test]
     fn test_builder_no_local() {
-        let opts = SubscribeOptionsBuilder::new()
-            .no_local(true)
-            .finalize();
+        let opts = SubscribeOptionsBuilder::new().no_local(true).finalize();
 
         assert!(opts.copts.noLocal != 0);
         assert!(opts.copts.retainAsPublished == 0);
@@ -252,4 +246,3 @@ mod tests {
         assert!(opts.copts.retainHandling == 2);
     }
 }
-

--- a/src/topic.rs
+++ b/src/topic.rs
@@ -1,5 +1,5 @@
 // topic.rs
-// 
+//
 // A set of message parameters to repeatedly publish to the same topic.
 //
 // This file is part of the Eclipse Paho MQTT Rust Client library.
@@ -23,12 +23,9 @@
 
 use crate::{
     async_client::AsyncClient,
-    token::{
-        Token,
-        DeliveryToken,
-    },
-    subscribe_options::SubscribeOptions,
     message::Message,
+    subscribe_options::SubscribeOptions,
+    token::{DeliveryToken, Token},
 };
 
 /////////////////////////////////////////////////////////////////////////////
@@ -49,8 +46,7 @@ pub struct Topic<'a> {
     retained: bool,
 }
 
-impl<'a> Topic<'a> 
-{
+impl<'a> Topic<'a> {
     /// Creates a new topic object for publishing messages.
     ///
     /// # Arguments
@@ -60,7 +56,8 @@ impl<'a> Topic<'a>
     /// `qos` The quality of service for messages
     ///
     pub fn new<T>(cli: &'a AsyncClient, topic: T, qos: i32) -> Topic<'a>
-        where T: Into<String>
+    where
+        T: Into<String>,
     {
         Topic {
             cli,
@@ -79,7 +76,8 @@ impl<'a> Topic<'a>
     /// `qos` The quality of service for messages
     ///
     pub fn new_retained<T>(cli: &'a AsyncClient, topic: T, qos: i32) -> Topic<'a>
-        where T: Into<String>
+    where
+        T: Into<String>,
     {
         Topic {
             cli,
@@ -96,9 +94,11 @@ impl<'a> Topic<'a>
 
     /// Subscribe to the topic with subscription options.
     pub fn subscribe_with_options<T>(&self, opts: T) -> Token
-        where T: Into<SubscribeOptions>
+    where
+        T: Into<SubscribeOptions>,
     {
-        self.cli.subscribe_with_options(self.topic.clone(), self.qos, opts)
+        self.cli
+            .subscribe_with_options(self.topic.clone(), self.qos, opts)
     }
 
     /// Publish a message on the topic.
@@ -108,11 +108,11 @@ impl<'a> Topic<'a>
     /// `payload` The payload of the message
     ///
     pub fn publish<V>(&self, payload: V) -> DeliveryToken
-        where V: Into<Vec<u8>>
+    where
+        V: Into<Vec<u8>>,
     {
         // OPTIMIZE: This could be more efficient.
         let msg = Message::new(self.topic.clone(), payload, self.qos);
         self.cli.publish(msg)
     }
 }
-

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,6 @@ pub const MQTT_VERSION_3_1_1: u32 = ffi::MQTTVERSION_3_1_1;
 /// Connect with MQTT v5
 pub const MQTT_VERSION_5: u32 = ffi::MQTTVERSION_5;
 
-
 /// Quality of Service Zero: At most once
 pub const QOS_0: i32 = 0;
 
@@ -47,5 +46,3 @@ pub const QOS_1: i32 = 1;
 
 /// Quality of Service Two: Exactly Once
 pub const QOS_2: i32 = 2;
-
-


### PR DESCRIPTION
I was making a change in this package as preparation for a PR, but noticed a lot of changes were caused by my editor (which is configured to format the file on save using the rust-analyzer).

So before making any functional changes, I thought to just make a PR which only contains the changes caused by running `cargo fmt --all`. So to be clear, I made **no** functional changes. These are all **only** formatting changes.