### PR TITLE
Add `Send` bounds to `ClientPersistence` to support async use of `CreateOptions`

### DIFF
--- a/src/client_persistence.rs
+++ b/src/client_persistence.rs
@@ -90,14 +90,14 @@ pub struct UserPersistence {
     /// The underlying struct for the C library
     pub(crate) copts: ffi::MQTTClient_persistence,
     // The user-supplied persistence object
-    persistence: Box<Box<dyn ClientPersistence>>,
+    persistence: Box<Box<dyn ClientPersistence + Send>>,
 }
 
 impl UserPersistence
 {
     /// Creates a new user persistence object.
-    pub fn new(mut persistence: Box<Box<dyn ClientPersistence>>) -> UserPersistence {
-        let context = &mut *persistence as *mut Box<dyn ClientPersistence> as _;
+    pub fn new(mut persistence: Box<Box<dyn ClientPersistence + Send>>) -> UserPersistence {
+        let context = &mut *persistence as *mut Box<dyn ClientPersistence + Send> as _;
 
         UserPersistence {
             copts: ffi::MQTTClient_persistence {

--- a/src/create_options.rs
+++ b/src/create_options.rs
@@ -47,7 +47,7 @@ pub enum PersistenceType {
 	/// No persistence is used.
 	None,
 	/// A user-defined persistence provided by the application.
-	User(Box<Box<dyn ClientPersistence>>),
+	User(Box<Box<dyn ClientPersistence + Send>>),
 }
 
 impl fmt::Debug for PersistenceType {
@@ -236,9 +236,9 @@ impl CreateOptionsBuilder {
 	/// `persist` An application-defined custom persistence store.
 	///
 	pub fn user_persistence<T>(mut self, persistence: T) -> Self
-			where T: ClientPersistence + 'static
+			where T: ClientPersistence + Send + 'static
 	{
-		let persistence: Box<Box<dyn ClientPersistence>> = Box::new(Box::new(persistence));
+		let persistence: Box<Box<dyn ClientPersistence + Send>> = Box::new(Box::new(persistence));
 		self.persistence = PersistenceType::User(persistence);
 		self
 	}


### PR DESCRIPTION
This allows `CreateOptions` to be used across async bounds, required for non-default client configuration. Without this patch using a `CreateOptionsBuilder` (rather than the inline `CreateOptions::new()`) causes the following error:

```
error: future cannot be sent between threads safely
  --> src/drivers/mqtt.rs:28:68
   |
28 |       async fn new(&self, id: String) -> Result<Self::Client, Error> {
   |  ____________________________________________________________________^
29 | |         // Create client with URI and ID
30 | |         let client_opts = paho_mqtt::CreateOptionsBuilder::new()
31 | |             .server_uri(self.server.as_str())
...  |
48 | |         Ok(MqttClient{client, rx})
49 | |     }
   | |_____^ future returned by `__new` is not `Send`
   |
   = help: the trait `std::marker::Send` is not implemented for `(dyn paho_mqtt::client_persistence::ClientPersistence + 'static)`
note: future is not `Send` as this value is used across an await
```

Signed-off-by: Ryan Kurte <ryan@kurte.nz>
