### PR TITLE
Set `opts` if calling `subscribeMany` with 1 topic

### DIFF
--- a/src/response_options.rs
+++ b/src/response_options.rs
@@ -172,7 +172,12 @@ impl ResponseOptionsBuilder {
 
     /// Sets a single set of subscribe options - for a call to subscribe_many()
     pub fn subscribe_many_options(&mut self, opts: &[SubscribeOptions]) -> &mut Self {
-        self.data.sub_opts = Some(opts.iter().map(|opt| opt.copts).collect());
+        match opts {
+            [] => {}
+            // This is necessary, as the `MQTTAsync_subscribeMany` paho.mqtt.c function uses `opts` over `optlist` when `count <= 1`
+            [opts] => self.copts.subscribeOptions = opts.copts,
+            _ => self.data.sub_opts = Some(opts.iter().map(|opt| opt.copts).collect())
+        }
         self
     }
 


### PR DESCRIPTION
fixes #120

### Concerns:
 1. should this check live in the underlying `ResponseOptionsBuilder::subscribe_many_options` instead?
 1. are there any tests that need to be added for this? The underlying issue is in the C library
 1. not sure about formating, rustfmt makes a ton of changes to this and other files both on `+stable` and `+nightly`, this should probably be addressed separately. Probably not checked in CI. I tried to format sensibly by hand.