### PR TITLE
Use default trait

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -145,8 +145,8 @@ impl AsyncClient {
 
         let mut cli = InnerAsyncClient {
             handle: ptr::null_mut(),
-            opts: Mutex::new(ConnectOptions::new()),
-            callback_context: Mutex::new(CallbackContext::default()),
+            opts: Default::default(),
+            callback_context: Default::default(),
             server_uri: CString::new(opts.server_uri)?,
             client_id: CString::new(opts.client_id)?,
             user_persistence: None,


### PR DESCRIPTION
Git diff looks very confused, but I just unwrapped the
```rust
fn fun(&self, x: impl Into<Option<X>>){
    if let Some(x) = x.into() {
        // do stuff
    } else {
        self.fun(X::default())
    }
}
```
constructs in `connect`, `disconnect` into
```rust
fn fun(&self, x: impl Into<Option<X>>){
    let x = x.into().unwrap_or_default();
    // do stuff
}
```