### PR TITLE
AsyncClient::get_stream() support unbounded channel

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1087,14 +1087,18 @@ impl AsyncClient {
     /// gets disconnected, it will insert `None` into the channel to signal
     /// the app about the disconnect.
     ///
+    /// The stream will rely on a bounded channel with the given buffer
+    /// capacity if 'buffer_sz' is 'Some' or will rely on an unbounded channel
+    /// if 'buffer_sz' is 'None'.
+    /// 
     /// It's a best practice to open the stream _before_ connecting to the
     /// server. When using persistent (non-clean) sessions, messages could
     /// arriving as soon as the connection is made - even before the
     /// connect() call returns.
-    pub fn get_stream(&mut self, buffer_sz: usize) -> AsyncReceiver<Option<Message>> {
+    pub fn get_stream(&mut self, buffer_sz: Option<usize>) -> AsyncReceiver<Option<Message>> {
         let (tx, rx) = match buffer_sz {
-            0 => async_channel::unbounded(),
-            cap => async_channel::bounded(cap),
+            None => async_channel::unbounded(),
+            Some(capacity) => async_channel::bounded(capacity),
         };
 
         // Make sure at least the low-level connection_lost handler is in

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -1092,7 +1092,10 @@ impl AsyncClient {
     /// arriving as soon as the connection is made - even before the
     /// connect() call returns.
     pub fn get_stream(&mut self, buffer_sz: usize) -> AsyncReceiver<Option<Message>> {
-        let (tx, rx) = async_channel::bounded(buffer_sz);
+        let (tx, rx) = match buffer_sz {
+            0 => async_channel::unbounded(),
+            cap => async_channel::bounded(cap),
+        };
 
         // Make sure at least the low-level connection_lost handler is in
         // place to notify us when the connection is lost (sends a 'None' to


### PR DESCRIPTION
Sometimes, a MQTT broker provides a lot of topics with a retain message for each of them.
Within current implementation, `AsyncClient` relies on a bounded channel that may be fully filled very quickly, even if messages are consumed and processed very fast. Fully filled the bounded channel results in losing messages. Note that I tried to determinate the relevant channel buffer capacity, but this might be difficult.
This PR aims to fix losing messages by using an unbounded channel if `buffer_sz` is `0`. This way, the underlying channel will grow up automatically to buffer all received messages.
Of course, this is not the ideal solution for all use cases because of the memory footprint. I think that a MQTT broker usually does not provide so many topics with retain messages. So generally setting `buffer_sz` to a positive number is the way to go.