### PR TITLE
Fix disconnect timeout

### DIFF
--- a/src/disconnect_options.rs
+++ b/src/disconnect_options.rs
@@ -116,10 +116,10 @@ impl DisconnectOptionsBuilder {
     /// # Arguments
     ///
     /// `timeout` The time interval to allow the disconnect to
-    ///           complete. This has a resolution of seconds.
+    ///           complete. This has a resolution of milliseconds.
     pub fn timeout(&mut self, timeout: Duration) -> &mut Self {
-        let secs = timeout.as_secs();
-        self.copts.timeout = if secs == 0 { 1 } else { secs as i32 };
+        let millis = timeout.as_millis();
+        self.copts.timeout = if millis == 0 { 1 } else { millis as i32 };
         self
     }
 


### PR DESCRIPTION
The C library is expecting the disconnect timeout to be [given in milliseconds](https://eclipse.github.io/paho.mqtt.c/MQTTAsync/html/struct_m_q_t_t_async__disconnect_options.html#a493b57f443cc38b3d3df9c1e584d9d82), but we were passing an integer with seconds.